### PR TITLE
feat: stabilize qiq php injection behavior

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -24,15 +25,29 @@ dependencies {
     intellijPlatform {
         phpstorm("2024.2")                 // ← PhpStorm 2024.2 をビルドターゲットに
         bundledPlugin("com.jetbrains.php") // ← PhpLanguage 等が解決される
+        testFramework(TestFrameworkType.Platform)
+        testFramework(TestFrameworkType.JUnit5)
     }
     testImplementation(kotlin("test"))
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+    testRuntimeOnly("junit:junit:4.13.2")
+}
+
+val intellijTestDependencies = configurations.named("intellijPlatformTestDependencies")
+
+configurations.named("testImplementation") {
+    extendsFrom(intellijTestDependencies.get())
+}
+
+configurations.named("testRuntimeOnly") {
+    extendsFrom(intellijTestDependencies.get())
 }
 
 intellijPlatform {
     pluginConfiguration {
         name.set("Qiq Templates Support")
         id.set("io.github.jingu.idea-qiq-plugin")
-        version.set("0.1.0")
+        version.set("0.2.0")
         ideaVersion {
             sinceBuild.set("241")
             untilBuild.set("253.*")

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjector.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjector.kt
@@ -108,7 +108,7 @@ class QiqPhpInjector : MultiHostInjector, DumbAware {
         if (trimmedContent.isEmpty()) return null
 
         var prefix = "<?php "
-        var suffix = " ?>\n"
+        var suffix = " ?>"
         var injectionRange = range
 
         if (isPrintLike) {
@@ -123,7 +123,7 @@ class QiqPhpInjector : MultiHostInjector, DumbAware {
             }
 
             prefix = "<?= "
-            suffix = " ?>\n"
+            suffix = " ?>"
         } else {
             val lower = trimmedContent.lowercase(Locale.ROOT)
 
@@ -131,7 +131,7 @@ class QiqPhpInjector : MultiHostInjector, DumbAware {
             val needsSemicolon = !trimmedContent.endsWith(";") && !trimmedContent.endsWith(":") &&
                 head !in setOf("else", "elseif", "case", "default")
 
-            if (needsSemicolon) suffix = "; ?>\n"
+            if (needsSemicolon) suffix = "; ?>"
         }
 
         return PhpInjectionFragment(host, injectionRange, prefix, suffix)
@@ -155,7 +155,7 @@ class QiqPhpInjector : MultiHostInjector, DumbAware {
 
         val range = TextRange(0, raw.length)
 
-        return PhpInjectionFragment(host, range, "<?php ", " ?>\n")
+        return PhpInjectionFragment(host, range, "<?php ", " ?>")
     }
 
     override fun elementsToInjectIn(): List<Class<out PsiElement>> =

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjector.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjector.kt
@@ -4,8 +4,12 @@ import com.intellij.lang.injection.MultiHostInjector
 import com.intellij.lang.injection.MultiHostRegistrar
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiLanguageInjectionHost
+import com.intellij.psi.util.PsiTreeUtil
 import com.jetbrains.php.lang.PhpLanguage
 import io.github.jingu.idea_qiq_plugin.psi.QiqCodeHost
 import io.github.jingu.idea_qiq_plugin.psi.QiqPhpHost
@@ -20,37 +24,91 @@ class QiqPhpInjector : MultiHostInjector, DumbAware {
 
     private val log = Logger.getInstance(QiqPhpInjector::class.java)
 
+    private data class InjectionPlan(
+        val modificationStamp: Long,
+        val fragments: List<PhpInjectionFragment>
+    )
+
+    private val injectionPlanKey = Key.create<InjectionPlan>(
+        "io.github.jingu.idea_qiq_plugin.inject.QiqPhpInjector.PLAN"
+    )
+
     override fun getLanguagesToInject(registrar: MultiHostRegistrar, host: PsiElement) {
-        when (host) {
-            is QiqCodeHost -> injectIntoQiqCodeHost(registrar, host)
-            is QiqPhpHost -> injectIntoQiqPhpHost(registrar, host)
+        if (host !is QiqCodeHost && host !is QiqPhpHost) return
+
+        val file = host.containingFile ?: return
+        val modificationStamp = file.modificationStamp
+
+        val plan = ensureInjectionPlan(file, modificationStamp)
+        if (plan.fragments.isEmpty()) return
+        if (plan.fragments.none { it.host == host }) return
+        if (!host.isValid) return
+
+        registrar.startInjecting(PhpLanguage.INSTANCE)
+        plan.fragments.forEach { fragment ->
+            registrar.addPlace(fragment.prefix, fragment.suffix, fragment.host, fragment.range)
         }
+        registrar.doneInjecting()
     }
 
-    private fun injectIntoQiqCodeHost(registrar: MultiHostRegistrar, host: QiqCodeHost) {
-        if (!host.isValidHost) return
+    private fun ensureInjectionPlan(file: PsiFile, modificationStamp: Long): InjectionPlan {
+        val existing = file.getUserData(injectionPlanKey)
+        if (existing != null && existing.modificationStamp == modificationStamp) {
+            return existing
+        }
+
+        val injectionHosts = collectInjectionHosts(file)
+        val fragments = injectionHosts.mapNotNull { buildInjectionFragment(it) }
+        val plan = InjectionPlan(modificationStamp, fragments)
+        file.putUserData(injectionPlanKey, plan)
+        return plan
+    }
+
+    private fun collectInjectionHosts(file: PsiFile): List<PsiLanguageInjectionHost> {
+        val codeHosts = PsiTreeUtil.collectElementsOfType(file, QiqCodeHost::class.java)
+        val phpHosts = PsiTreeUtil.collectElementsOfType(file, QiqPhpHost::class.java)
+
+        return (codeHosts.asSequence() + phpHosts.asSequence())
+            .filter { it.isValidHost }
+            .sortedBy { it.textRange.startOffset }
+            .toList()
+    }
+
+    private data class PhpInjectionFragment(
+        val host: PsiLanguageInjectionHost,
+        val range: TextRange,
+        val prefix: String?,
+        val suffix: String?
+    )
+
+    private fun buildInjectionFragment(host: PsiLanguageInjectionHost): PhpInjectionFragment? = when (host) {
+        is QiqCodeHost -> buildCodeHostFragment(host)
+        is QiqPhpHost -> buildPhpHostFragment(host)
+        else -> null
+    }
+
+    private fun buildCodeHostFragment(host: QiqCodeHost): PhpInjectionFragment? {
+        if (!host.isValidHost) return null
 
         val raw = host.text
-        if (raw.isEmpty()) return
+        if (raw.isEmpty()) return null
 
-        // Debug hook (will appear in idea.log)
         log.debug("QiqPhpInjector: QiqCodeHost, text='${raw.take(40)}'")
 
-        // Skip leading whitespace for injection
         val leadingWs = raw.indexOfFirst { !it.isWhitespace() }.let { if (it == -1) raw.length else it }
-        if (leadingWs >= raw.length) return
+        if (leadingWs >= raw.length) return null
 
         val lastContentIndex = raw.indexOfLast { !it.isWhitespace() }
-        if (lastContentIndex < leadingWs) return
+        if (lastContentIndex < leadingWs) return null
 
         var range = TextRange(leadingWs, lastContentIndex + 1)
 
         val isPrintLike = host.isPrintLike()
-        var trimmedContent = raw.substring(range.startOffset, range.endOffset).trim()
-        if (trimmedContent.isEmpty()) return
+        val trimmedContent = raw.substring(range.startOffset, range.endOffset).trim()
+        if (trimmedContent.isEmpty()) return null
 
         var prefix = "<?php "
-        var suffix = " ?>"
+        var suffix = " ?>\n"
         var injectionRange = range
 
         if (isPrintLike) {
@@ -60,38 +118,23 @@ class QiqPhpInjector : MultiHostInjector, DumbAware {
                 while (newStart < range.endOffset && raw[newStart].isWhitespace()) {
                     newStart++
                 }
-                if (newStart >= range.endOffset) return
+                if (newStart >= range.endOffset) return null
                 injectionRange = TextRange(newStart, range.endOffset)
             }
-            val injectionContent = raw.substring(injectionRange.startOffset, injectionRange.endOffset)
-            val variables = extractVariables(injectionContent)
-            prefix = buildPrintPrefix(variables)
-            suffix = " ?>"
+
+            prefix = "<?= "
+            suffix = " ?>\n"
         } else {
             val lower = trimmedContent.lowercase(Locale.ROOT)
 
-            val closingStub = closingDirectiveBody(lower)
-            if (closingStub != null) {
-                prefix += closingStub
-                suffix = "; ?>"
-            } else {
-                val head = lower.substringBefore(' ')
-                val needsSemicolon = !trimmedContent.endsWith(";") && !trimmedContent.endsWith(":") &&
-                    head !in setOf("else", "elseif", "case", "default")
+            val head = lower.substringBefore(' ')
+            val needsSemicolon = !trimmedContent.endsWith(";") && !trimmedContent.endsWith(":") &&
+                head !in setOf("else", "elseif", "case", "default")
 
-                if (needsSemicolon) suffix = "; ?>"
-            }
+            if (needsSemicolon) suffix = "; ?>\n"
         }
 
-        registrar.startInjecting(PhpLanguage.INSTANCE)
-        registrar.addPlace(prefix, suffix, host, injectionRange)
-        registrar.doneInjecting()
-    }
-
-    private fun buildPrintPrefix(variables: Set<String>): String {
-        if (variables.isEmpty()) return "<?= "
-        val annotations = variables.joinToString(separator = " ") { "/** @var mixed $it */" }
-        return "<?php $annotations ?><?= "
+        return PhpInjectionFragment(host, injectionRange, prefix, suffix)
     }
 
     private fun extractVariables(content: String): Set<String> {
@@ -102,32 +145,17 @@ class QiqPhpInjector : MultiHostInjector, DumbAware {
             .toSet()
     }
 
-    private fun closingDirectiveBody(lowerContent: String): String? {
-        return when {
-            lowerContent.startsWith("endif") -> "if (false): "
-            lowerContent.startsWith("endforeach") -> "foreach ([] as ${'$'}__qiqStub): "
-            lowerContent.startsWith("endfor") -> "for (${ '$' }__qiqI = 0; ${ '$' }__qiqI < 0; ${ '$' }__qiqI++): "
-            lowerContent.startsWith("endwhile") -> "while (false): "
-            lowerContent.startsWith("endswitch") -> "switch (false): "
-            else -> null
-        }
-    }
-
-    private fun injectIntoQiqPhpHost(registrar: MultiHostRegistrar, host: QiqPhpHost) {
-        if (!host.isValidHost) return
+    private fun buildPhpHostFragment(host: QiqPhpHost): PhpInjectionFragment? {
+        if (!host.isValidHost) return null
 
         val raw = host.text
-        if (raw.isEmpty()) return
+        if (raw.isEmpty()) return null
 
-        // Debug hook (will appear in idea.log)
         log.debug("QiqPhpInjector: QiqPhpHost, text='${raw.take(40)}'")
 
-        // For PHP blocks, inject the entire content as PHP
         val range = TextRange(0, raw.length)
 
-        registrar.startInjecting(PhpLanguage.INSTANCE)
-        registrar.addPlace("<?php ", " ?>", host, range)
-        registrar.doneInjecting()
+        return PhpInjectionFragment(host, range, "<?php ", " ?>\n")
     }
 
     override fun elementsToInjectIn(): List<Class<out PsiElement>> =

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/lang/QiqFileTypeOverrider.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/lang/QiqFileTypeOverrider.kt
@@ -30,6 +30,11 @@ class QiqFileTypeOverrider : FileTypeOverrider {
         try {
             if (file.isDirectory) return null
 
+            // 既に Qiq として扱ったファイルは継続して Qiq を返す（再判定で PHP に戻さない）
+            if (file.getUserData(QIQ_MARKER) == true) {
+                return QiqFileType
+            }
+
             // 1) Qiq専用拡張子は即スキップ（拡張子のみでQiqに確定させる）
             //    注意: file.extension は最後のドット以降のみ（".qiq.php" の extension は "php"）
             val nameLower = file.nameSequence.toString().lowercase()

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/navigation/QiqReferenceContributor.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/navigation/QiqReferenceContributor.kt
@@ -13,14 +13,9 @@ import com.jetbrains.php.lang.psi.elements.StringLiteralExpression
 import io.github.jingu.idea_qiq_plugin.lang.QiqFileType
 import io.github.jingu.idea_qiq_plugin.lang.QiqTemplateLanguage
 import io.github.jingu.idea_qiq_plugin.util.QiqUtil
-import com.intellij.openapi.diagnostic.Logger
 
 class QiqReferenceContributor : PsiReferenceContributor() {
-    private val LOG = Logger.getInstance(QiqReferenceContributor::class.java)
-
     override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) {
-        LOG.info("QiqReferenceContributor: Registering reference providers")
-
         registrar.registerReferenceProvider(
             PlatformPatterns.psiElement(StringLiteralExpression::class.java),
             object : PsiReferenceProvider() {
@@ -45,13 +40,10 @@ class QiqReferenceContributor : PsiReferenceContributor() {
                     val contextVirtualFile = ilm.getTopLevelFile(element)?.virtualFile
                         ?: element.containingFile?.virtualFile
 
-                    LOG.debug("QiqReferenceContributor: Creating reference for path '$path'")
                     return arrayOf(QiqIncludeReference(element, path, range, contextVirtualFile))
                 }
             }
         )
-
-        LOG.info("QiqReferenceContributor: Reference providers registration completed")
     }
 
     private fun isInQiqFile(element: PsiElement): Boolean {
@@ -88,10 +80,7 @@ class QiqIncludeReference(
 ) :
     PsiReferenceBase<PsiElement>(element, rangeInElement ?: com.intellij.openapi.util.TextRange(0, element.textLength), true) {
 
-    private val LOG = Logger.getInstance(QiqIncludeReference::class.java)
-
     override fun resolve(): PsiElement? {
-        LOG.info("QiqIncludeReference: Attempting to resolve path: '$path'")
         val contextFile = contextVirtualFile ?: element.containingFile?.virtualFile
         val result = QiqUtil.findTemplateByPath(element.project, path, contextFile)
 

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjectorTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjectorTest.kt
@@ -46,10 +46,8 @@ class QiqPhpInjectorTest {
         )
 
         val expected = """
-            <?php foreach (${ '$'}items as ${ '$'}item): ?>
-            <?= ${ '$'}item->name ?>
-            <?php endforeach; ?>
-            """.trimIndent() + "\n"
+            <?php foreach (${ '$'}items as ${ '$'}item): ?><?= ${ '$'}item->name ?><?php endforeach; ?>
+            """.trimIndent()
 
         ApplicationManager.getApplication().runReadAction {
             val hosts = PsiTreeUtil.collectElementsOfType(psiFile, QiqCodeHost::class.java).toList()

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjectorTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjectorTest.kt
@@ -53,14 +53,14 @@ class QiqPhpInjectorTest {
 
         ApplicationManager.getApplication().runReadAction {
             val hosts = PsiTreeUtil.collectElementsOfType(psiFile, QiqCodeHost::class.java).toList()
-            assertEquals(3, hosts.size, "想定した QiqCodeHost 数と一致しません")
+            assertEquals(3, hosts.size, "Unexpected number of QiqCodeHost elements")
 
             val registrar = RecordingRegistrar()
             injector.getLanguagesToInject(registrar, hosts.first())
 
             val phpCalls = registrar.calls.filter { it.language == PhpLanguage.INSTANCE }
-            assertEquals(3, phpCalls.size, "PHP インジェクション断片が不足しています")
-            assertEquals(hosts.toSet(), phpCalls.map { it.host }.toSet(), "全ホストが注入対象になっていません")
+            assertEquals(3, phpCalls.size, "Missing PHP injection fragments")
+            assertEquals(hosts.toSet(), phpCalls.map { it.host }.toSet(), "Not all hosts received injections")
 
             val assembled = assembleInjectedText(phpCalls)
             assertEquals(expected, assembled)
@@ -72,7 +72,7 @@ class QiqPhpInjectorTest {
                 assertEquals(
                     3,
                     perHostCalls.size,
-                    "ホスト ${'$'}{host.text} の注入結果が一貫していません"
+                    "Injection result is inconsistent for host ${'$'}{host.text}"
                 )
             }
         }
@@ -104,7 +104,7 @@ class QiqPhpInjectorTest {
         }
 
         override fun addPlace(prefix: String?, suffix: String?, host: PsiLanguageInjectionHost, range: TextRange): MultiHostRegistrar {
-            val language = requireNotNull(currentLanguage) { "startInjecting を呼び出す前に addPlace が呼ばれました" }
+            val language = requireNotNull(currentLanguage) { "addPlace called before startInjecting" }
             calls += RecordedCall(language, prefix, suffix, host, range)
             return this
         }
@@ -124,7 +124,7 @@ class QiqPhpInjectorTest {
         }
 
         fun addPlace(prefix: String?, suffix: String?, host: PsiElement, range: TextRange): MultiHostRegistrar {
-            require(host is PsiLanguageInjectionHost) { "PsiLanguageInjectionHost が必要です" }
+            require(host is PsiLanguageInjectionHost) { "PsiLanguageInjectionHost required" }
             return addPlace(prefix, suffix, host, range)
         }
 

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjectorTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjectorTest.kt
@@ -1,0 +1,144 @@
+package io.github.jingu.idea_qiq_plugin.inject
+
+import com.intellij.lang.Language
+import com.intellij.lang.injection.MultiHostRegistrar
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.PsiLanguageInjectionHost
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.testFramework.junit5.RunInEdt
+import com.intellij.testFramework.junit5.impl.TestApplicationExtension
+import com.intellij.testFramework.junit5.resources.ProjectExtension
+import com.jetbrains.php.lang.PhpLanguage
+import io.github.jingu.idea_qiq_plugin.lang.QiqFileType
+import io.github.jingu.idea_qiq_plugin.psi.QiqCodeHost
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.RegisterExtension
+
+@RunInEdt
+@ExtendWith(TestApplicationExtension::class)
+class QiqPhpInjectorTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val projectExtension = ProjectExtension()
+    }
+
+    private val injector = QiqPhpInjector()
+
+    @Test
+    fun aggregatesAllFragmentsIntoSinglePhpStream(project: Project) {
+        val psiFile = createQiqFile(
+            project,
+            """
+            {{ foreach (${ '$'}items as ${ '$'}item): }}
+            <li>{{h ${ '$'}item->name }}</li>
+            {{ endforeach }}
+            """.trimIndent()
+        )
+
+        val expected = """
+            <?php foreach (${ '$'}items as ${ '$'}item): ?>
+            <?= ${ '$'}item->name ?>
+            <?php endforeach; ?>
+            """.trimIndent() + "\n"
+
+        ApplicationManager.getApplication().runReadAction {
+            val hosts = PsiTreeUtil.collectElementsOfType(psiFile, QiqCodeHost::class.java).toList()
+            assertEquals(3, hosts.size, "想定した QiqCodeHost 数と一致しません")
+
+            val registrar = RecordingRegistrar()
+            injector.getLanguagesToInject(registrar, hosts.first())
+
+            val phpCalls = registrar.calls.filter { it.language == PhpLanguage.INSTANCE }
+            assertEquals(3, phpCalls.size, "PHP インジェクション断片が不足しています")
+            assertEquals(hosts.toSet(), phpCalls.map { it.host }.toSet(), "全ホストが注入対象になっていません")
+
+            val assembled = assembleInjectedText(phpCalls)
+            assertEquals(expected, assembled)
+
+            hosts.forEach { host ->
+                val perHostRegistrar = RecordingRegistrar()
+                injector.getLanguagesToInject(perHostRegistrar, host)
+                val perHostCalls = perHostRegistrar.calls.filter { it.language == PhpLanguage.INSTANCE }
+                assertEquals(
+                    3,
+                    perHostCalls.size,
+                    "ホスト ${'$'}{host.text} の注入結果が一貫していません"
+                )
+            }
+        }
+    }
+
+    private fun createQiqFile(project: Project, text: String): PsiFile {
+        return WriteAction.compute<PsiFile, RuntimeException> {
+            PsiFileFactory.getInstance(project).createFileFromText("sample.qiq", QiqFileType, text)
+        }
+    }
+
+    private fun assembleInjectedText(calls: List<RecordedCall>): String {
+        val builder = StringBuilder()
+        calls.forEach { call ->
+            call.prefix?.let(builder::append)
+            builder.append(call.host.text.substring(call.range.startOffset, call.range.endOffset))
+            call.suffix?.let(builder::append)
+        }
+        return builder.toString()
+    }
+
+    private class RecordingRegistrar : MultiHostRegistrar {
+        val calls = mutableListOf<RecordedCall>()
+        private var currentLanguage: Language? = null
+
+        override fun startInjecting(language: Language): MultiHostRegistrar {
+            currentLanguage = language
+            return this
+        }
+
+        override fun addPlace(prefix: String?, suffix: String?, host: PsiLanguageInjectionHost, range: TextRange): MultiHostRegistrar {
+            val language = requireNotNull(currentLanguage) { "startInjecting を呼び出す前に addPlace が呼ばれました" }
+            calls += RecordedCall(language, prefix, suffix, host, range)
+            return this
+        }
+
+        override fun doneInjecting() {
+            currentLanguage = null
+        }
+
+        fun clear() {
+            calls.clear()
+            currentLanguage = null
+        }
+
+        fun addPlace(prefix: String?, suffix: String?, host: PsiLanguageInjectionHost, ranges: List<TextRange>): MultiHostRegistrar {
+            ranges.forEach { addPlace(prefix, suffix, host, it) }
+            return this
+        }
+
+        fun addPlace(prefix: String?, suffix: String?, host: PsiElement, range: TextRange): MultiHostRegistrar {
+            require(host is PsiLanguageInjectionHost) { "PsiLanguageInjectionHost が必要です" }
+            return addPlace(prefix, suffix, host, range)
+        }
+
+        fun addPlace(prefix: String?, suffix: String?, host: PsiElement, ranges: List<TextRange>): MultiHostRegistrar {
+            ranges.forEach { addPlace(prefix, suffix, host, it) }
+            return this
+        }
+    }
+
+    private data class RecordedCall(
+        val language: Language,
+        val prefix: String?,
+        val suffix: String?,
+        val host: PsiLanguageInjectionHost,
+        val range: TextRange
+    )
+}

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjectorTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjectorTest.kt
@@ -110,26 +110,6 @@ class QiqPhpInjectorTest {
         override fun doneInjecting() {
             currentLanguage = null
         }
-
-        fun clear() {
-            calls.clear()
-            currentLanguage = null
-        }
-
-        fun addPlace(prefix: String?, suffix: String?, host: PsiLanguageInjectionHost, ranges: List<TextRange>): MultiHostRegistrar {
-            ranges.forEach { addPlace(prefix, suffix, host, it) }
-            return this
-        }
-
-        fun addPlace(prefix: String?, suffix: String?, host: PsiElement, range: TextRange): MultiHostRegistrar {
-            require(host is PsiLanguageInjectionHost) { "PsiLanguageInjectionHost required" }
-            return addPlace(prefix, suffix, host, range)
-        }
-
-        fun addPlace(prefix: String?, suffix: String?, host: PsiElement, ranges: List<TextRange>): MultiHostRegistrar {
-            ranges.forEach { addPlace(prefix, suffix, host, it) }
-            return this
-        }
     }
 
     private data class RecordedCall(

--- a/test_html.qiq
+++ b/test_html.qiq
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ $title ?? 'Default Title' }}</title>
+</head>
+<body>
+    <header>
+        <h1>{{ $heading }}</h1>
+        <nav>
+            <ul>
+                <li><a href="/">Home</a></li>
+                <li><a href="/about">About</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <div class="container">
+            {{ $content }}
+        </div>
+    </main>
+
+    <footer>
+        <p>&copy; 2025 Test Site</p>
+    </footer>
+</body>
+</html>
+

--- a/test_setlayout.qiq
+++ b/test_setlayout.qiq
@@ -1,0 +1,29 @@
+{{ setLayout ('layout/base') }}
+{{ setLayout('layout/main') }}
+{{ SETLAYOUT ('layout/admin') }}
+{{ render('template/user') }}
+
+<div class="container">
+    <h1>Welcome to Qiq Template</h1>
+    <p>This is a sample HTML content with <strong>bold text</strong> and <em>italic text</em>.</p>
+    <ul>
+        <li><a href="/home">Home</a></li>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+    </ul>
+    <form action="/submit" method="post">
+        <input type="text" name="username" placeholder="Enter username" />
+        <button type="submit">Submit</button>
+    </form>
+</div>
+
+<script>
+    console.log('JavaScript code should also be highlighted');
+</script>
+
+<style>
+    .container {
+        background-color: #f5f5f5;
+        padding: 20px;
+    }
+</style>

--- a/test_stub_functions.qiq
+++ b/test_stub_functions.qiq
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test Page</title>
+    {{ setLayout('layouts/main') }}
+</head>
+<body>
+    <h1>{{ $title }}</h1>
+
+    {{ setBlock('content') }}
+    <p>This is the main content.</p>
+    {{ endBlock() }}
+
+    <div>
+        {{ render('partials/sidebar', ['items' => $items]) }}
+    </div>
+
+    <form>
+        {{ textField('username', $username) }}
+        {{ passwordField('password') }}
+        {{ submitButton('Login') }}
+    </form>
+
+    {{ $this->anchor('/home', 'Home') }}
+    {{ $this->linkStylesheet('/css/style.css') }}
+</body>
+</html>
+

--- a/test_template_data_language.qiq
+++ b/test_template_data_language.qiq
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>{{= $title }}</title>
+</head>
+<body>
+    <h1>{{h $heading }}</h1>
+
+    <!-- PHP injection test -->
+    <?php
+    $user = getCurrentUser();
+    echo "Current user: " . $user->getName();
+    ?>
+
+    <div class="content">
+        {{= $content }}
+    </div>
+
+    <ul>
+        {{ foreach ($items as $item): }}
+            <li>{{h $item->name }}</li>
+        {{ endforeach }}
+    </ul>
+</body>
+</html>
+


### PR DESCRIPTION
## 変更概要
  - `build.gradle.kts:1-39` に IntelliJ テストフレームワーク（ `Platform/JUnit5` ）と `JUnit` 4/5 ランタイムを追加し`testImplementation` / `testRuntimeOnly` に取り込むよう設定
  - `src/main/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjector.kt` で PHP 注入処理を再構成し、ファイル単位のキャッシュ計画・ホスト収集・新たな断片生成ロジックを導入して安定性を向上
  - `src/main/kotlin/io/github/jingu/idea_qiq_plugin/lang/QiqFileTypeOverrider.kt` で一度 Qiq と判定したファイルを再判定でPHP に戻さないようマーカー判定を追加
  - `src/main/kotlin/io/github/jingu/idea_qiq_plugin/navigation/QiqReferenceContributor.kt` からデバッグログを削除し、参照生成処理を簡潔化
  - `src/test/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjectorTest.kt` に JUnit5 ベースの回帰テストを新設し、EDT実行・Read Action 内での検証・期待される PHP 断片の組み立てを確認するように改善
  - test_html.qiq ほか 3 つのサンプルテンプレートを追加し、手動検証用のフィクスチャを拡充

## Change Summary
- **build.gradle.kts:1-39**  
  Added the IntelliJ test framework (Platform/JUnit5) and JUnit 4/5 runtime, and configured them to be included in `testImplementation` / `testRuntimeOnly`.  

- **src/main/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjector.kt:1-190**  
  Reorganized the PHP injection process, introducing file-level cache planning, host collection, and new fragment generation logic to improve stability.  

- **src/main/kotlin/io/github/jingu/idea_qiq_plugin/lang/QiqFileTypeOverrider.kt:30-38**  
  Added a marker check to prevent files once identified as Qiq from being reclassified back to PHP upon re-evaluation.  

- **src/main/kotlin/io/github/jingu/idea_qiq_plugin/navigation/QiqReferenceContributor.kt:13-110**  
  Removed debug logs and simplified the reference generation process.  

- **src/test/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjectorTest.kt:1-144**  
  Created a new JUnit5-based regression test to verify EDT execution, validation within a Read Action, and assembly of expected PHP fragments.  

- **test_html.qiq** and three other sample templates were added to expand fixtures for manual verification.  