### PR TITLE
highlight extends directive

### DIFF
--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/highlight/QiqReservedDirectiveAnnotator.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/highlight/QiqReservedDirectiveAnnotator.kt
@@ -1,0 +1,64 @@
+package io.github.jingu.idea_qiq_plugin.highlight
+
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.Annotator
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import io.github.jingu.idea_qiq_plugin.psi.QiqCodeHost
+
+/**
+ * ハイライトから外れてしまう予約語系ディレクティブ (extends 等) の識別子に
+ * Qiq 固有のテキスト属性を適用するための Annotator。
+ */
+class QiqReservedDirectiveAnnotator : Annotator {
+
+    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+        if (element !is QiqCodeHost) return
+
+        val match = findReservedDirectiveSpan(element.text) ?: return
+
+        val startOffset = element.textRange.startOffset + match.startOffset
+        val endOffset = startOffset + match.length
+
+        holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+            .range(TextRange(startOffset, endOffset))
+            .textAttributes(QiqHighlighterKeys.FUNCTION)
+            .create()
+    }
+
+    companion object {
+        private val RESERVED_DIRECTIVE_FUNCTIONS = setOf("extends")
+
+        internal fun findReservedDirectiveSpan(text: String): Span? {
+            var index = 0
+            val length = text.length
+
+            while (index < length && text[index].isWhitespace()) {
+                index++
+            }
+
+            if (index >= length) return null
+            val nameStart = index
+
+            while (index < length && (text[index].isLetterOrDigit() || text[index] == '_')) {
+                index++
+            }
+
+            if (index == nameStart) return null
+            val name = text.substring(nameStart, index)
+            if (RESERVED_DIRECTIVE_FUNCTIONS.none { it.equals(name, ignoreCase = true) }) return null
+
+            var lookahead = index
+            while (lookahead < length && text[lookahead].isWhitespace()) {
+                lookahead++
+            }
+
+            if (lookahead >= length || text[lookahead] != '(') return null
+
+            return Span(nameStart, index - nameStart)
+        }
+    }
+
+    internal data class Span(val startOffset: Int, val length: Int)
+}

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/highlight/QiqReservedDirectiveAnnotator.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/highlight/QiqReservedDirectiveAnnotator.kt
@@ -3,9 +3,9 @@ package io.github.jingu.idea_qiq_plugin.highlight
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
 import com.intellij.lang.annotation.HighlightSeverity
-import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import io.github.jingu.idea_qiq_plugin.psi.QiqCodeHost
+import io.github.jingu.idea_qiq_plugin.util.QiqUtil
 
 /**
  * Annotator for applying Qiq-specific text attributes to reserved directive identifiers
@@ -16,49 +16,12 @@ class QiqReservedDirectiveAnnotator : Annotator {
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {
         if (element !is QiqCodeHost) return
 
-        val match = findReservedDirectiveSpan(element.text) ?: return
-
-        val startOffset = element.textRange.startOffset + match.startOffset
-        val endOffset = startOffset + match.length
+        val match = QiqUtil.findReservedDirectiveSpan(element.text) ?: return
+        val highlightRange = match.toTextRange(element.textRange.startOffset)
 
         holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
-            .range(TextRange(startOffset, endOffset))
+            .range(highlightRange)
             .textAttributes(QiqHighlighterKeys.FUNCTION)
             .create()
     }
-
-    companion object {
-        private val RESERVED_DIRECTIVE_FUNCTIONS = setOf("extends")
-
-        internal fun findReservedDirectiveSpan(text: String): Span? {
-            var index = 0
-            val length = text.length
-
-            while (index < length && text[index].isWhitespace()) {
-                index++
-            }
-
-            if (index >= length) return null
-            val nameStart = index
-
-            while (index < length && (text[index].isLetterOrDigit() || text[index] == '_')) {
-                index++
-            }
-
-            if (index == nameStart) return null
-            val name = text.substring(nameStart, index)
-            if (RESERVED_DIRECTIVE_FUNCTIONS.none { it.equals(name, ignoreCase = true) }) return null
-
-            var lookahead = index
-            while (lookahead < length && text[lookahead].isWhitespace()) {
-                lookahead++
-            }
-
-            if (lookahead >= length || text[lookahead] != '(') return null
-
-            return Span(nameStart, index - nameStart)
-        }
-    }
-
-    internal data class Span(val startOffset: Int, val length: Int)
 }

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/highlight/QiqReservedDirectiveAnnotator.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/highlight/QiqReservedDirectiveAnnotator.kt
@@ -8,8 +8,8 @@ import com.intellij.psi.PsiElement
 import io.github.jingu.idea_qiq_plugin.psi.QiqCodeHost
 
 /**
- * ハイライトから外れてしまう予約語系ディレクティブ (extends 等) の識別子に
- * Qiq 固有のテキスト属性を適用するための Annotator。
+ * Annotator for applying Qiq-specific text attributes to reserved directive identifiers
+ * (such as "extends") that would otherwise not be highlighted.
  */
 class QiqReservedDirectiveAnnotator : Annotator {
 

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjector.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjector.kt
@@ -13,6 +13,7 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.jetbrains.php.lang.PhpLanguage
 import io.github.jingu.idea_qiq_plugin.psi.QiqCodeHost
 import io.github.jingu.idea_qiq_plugin.psi.QiqPhpHost
+import io.github.jingu.idea_qiq_plugin.util.QiqUtil
 import java.util.Locale
 
 /**
@@ -151,26 +152,16 @@ class QiqPhpInjector : MultiHostInjector, DumbAware {
         val snippet = raw.substring(range.startOffset, range.endOffset)
         if (snippet.isEmpty()) return null
 
-        val leadingTrim = snippet.indexOfFirst { !it.isWhitespace() }.let { if (it == -1) 0 else it }
-        val trimmed = snippet.substring(leadingTrim)
-        if (trimmed.isEmpty()) return null
+        val span = QiqUtil.findReservedDirectiveSpan(snippet) ?: return null
 
-        val identifierEnd = trimmed.indexOfFirst { !it.isLetterOrDigit() && it != '_' }
-        if (identifierEnd == 0) return null
+        val parenIndex = snippet.indexOf('(', span.startOffset + span.length)
+        if (parenIndex == -1) return null
 
-        val name = if (identifierEnd == -1) trimmed else trimmed.substring(0, identifierEnd)
-        if (!name.equals("extends", ignoreCase = true)) return null
-
-        var offset = range.startOffset + leadingTrim + name.length
-        while (offset < range.endOffset && raw[offset].isWhitespace()) {
-            offset++
-        }
-
-        if (offset >= range.endOffset || raw[offset] != '(') return null
+        val injectionStart = range.startOffset + parenIndex
 
         return ReservedDirectiveRewrite(
             prefix = "<?php \\QiqRuntimeFunctions::extends",
-            range = TextRange(offset, range.endOffset)
+            range = TextRange(injectionStart, range.endOffset)
         )
     }
 

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjector.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjector.kt
@@ -81,6 +81,11 @@ class QiqPhpInjector : MultiHostInjector, DumbAware {
         val suffix: String?
     )
 
+    private data class ReservedDirectiveRewrite(
+        val prefix: String,
+        val range: TextRange
+    )
+
     private fun buildInjectionFragment(host: PsiLanguageInjectionHost): PhpInjectionFragment? = when (host) {
         is QiqCodeHost -> buildCodeHostFragment(host)
         is QiqPhpHost -> buildPhpHostFragment(host)
@@ -127,6 +132,11 @@ class QiqPhpInjector : MultiHostInjector, DumbAware {
         } else {
             val lower = trimmedContent.lowercase(Locale.ROOT)
 
+            rewriteReservedDirective(raw, range)?.let {
+                prefix = it.prefix
+                injectionRange = it.range
+            }
+
             val head = lower.substringBefore(' ')
             val needsSemicolon = !trimmedContent.endsWith(";") && !trimmedContent.endsWith(":") &&
                 head !in setOf("else", "elseif", "case", "default")
@@ -137,12 +147,31 @@ class QiqPhpInjector : MultiHostInjector, DumbAware {
         return PhpInjectionFragment(host, injectionRange, prefix, suffix)
     }
 
-    private fun extractVariables(content: String): Set<String> {
-        val regex = Regex("\\$[a-zA-Z_][a-zA-Z0-9_]*")
-        return regex.findAll(content)
-            .map { it.value }
-            .filterNot { it == "\$this" }
-            .toSet()
+    private fun rewriteReservedDirective(raw: String, range: TextRange): ReservedDirectiveRewrite? {
+        val snippet = raw.substring(range.startOffset, range.endOffset)
+        if (snippet.isEmpty()) return null
+
+        val leadingTrim = snippet.indexOfFirst { !it.isWhitespace() }.let { if (it == -1) 0 else it }
+        val trimmed = snippet.substring(leadingTrim)
+        if (trimmed.isEmpty()) return null
+
+        val identifierEnd = trimmed.indexOfFirst { !it.isLetterOrDigit() && it != '_' }
+        if (identifierEnd == 0) return null
+
+        val name = if (identifierEnd == -1) trimmed else trimmed.substring(0, identifierEnd)
+        if (!name.equals("extends", ignoreCase = true)) return null
+
+        var offset = range.startOffset + leadingTrim + name.length
+        while (offset < range.endOffset && raw[offset].isWhitespace()) {
+            offset++
+        }
+
+        if (offset >= range.endOffset || raw[offset] != '(') return null
+
+        return ReservedDirectiveRewrite(
+            prefix = "<?php \\QiqRuntimeFunctions::extends",
+            range = TextRange(offset, range.endOffset)
+        )
     }
 
     private fun buildPhpHostFragment(host: QiqPhpHost): PhpInjectionFragment? {

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/util/QiqUtil.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/util/QiqUtil.kt
@@ -1,12 +1,44 @@
 package io.github.jingu.idea_qiq_plugin.util
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiManager
 import io.github.jingu.idea_qiq_plugin.settings.QiqSettingsService
 
 object QiqUtil {
+    private val reservedDirectiveNames = setOf("extends")
+
+    fun findReservedDirectiveSpan(text: String, directives: Set<String> = reservedDirectiveNames): ReservedDirectiveSpan? {
+        var index = 0
+        val length = text.length
+
+        while (index < length && text[index].isWhitespace()) {
+            index++
+        }
+
+        if (index >= length) return null
+        val nameStart = index
+
+        while (index < length && (text[index].isLetterOrDigit() || text[index] == '_')) {
+            index++
+        }
+
+        if (index == nameStart) return null
+        val name = text.substring(nameStart, index)
+        if (directives.none { it.equals(name, ignoreCase = true) }) return null
+
+        var lookahead = index
+        while (lookahead < length && text[lookahead].isWhitespace()) {
+            lookahead++
+        }
+
+        if (lookahead >= length || text[lookahead] != '(') return null
+
+        return ReservedDirectiveSpan(nameStart, index - nameStart)
+    }
+
     fun isIncludePath(value: String): Boolean {
         val v = value.trim()
 
@@ -65,4 +97,9 @@ object QiqUtil {
 
         return null
     }
+}
+
+data class ReservedDirectiveSpan(val startOffset: Int, val length: Int) {
+    fun toTextRange(baseOffset: Int): TextRange =
+        TextRange(baseOffset + startOffset, baseOffset + startOffset + length)
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -34,6 +34,9 @@
         <editorHighlighterProvider
                 implementationClass="io.github.jingu.idea_qiq_plugin.highlight.QiqEditorHighlighterProvider"
                 filetype="Qiq"/>
+        <annotator
+                language="Qiq"
+                implementationClass="io.github.jingu.idea_qiq_plugin.highlight.QiqReservedDirectiveAnnotator"/>
 
         <!-- Color Settings Page -->
         <colorSettingsPage implementation="io.github.jingu.idea_qiq_plugin.ui.QiqColorSettingsPage"/>

--- a/src/main/resources/library/qiq_runtime.php
+++ b/src/main/resources/library/qiq_runtime.php
@@ -12,7 +12,6 @@
  * --------------------------- */
 function render(string $path, ...$args): string {}
 function setLayout(string $path): void {}
-function extends(string $path): void {}
 
 /* ---------------------------
  * Blocks (functions)
@@ -52,6 +51,19 @@ function ul(array $items, array $attrs = []): string { return ''; }
 /* 1.x/2.x compatibility helpers */
 function metaName($name, $content, array $attrs = []): string { return ''; }     // 1.x/2.x
 function metaHttp($httpEquiv, $content, array $attrs = []): string { return ''; } // 1.x/2.x
+
+/* ------------------------------------------------------
+ * Helper wrapper for reserved-word directives like extends
+ * ------------------------------------------------------ */
+if (!class_exists('QiqRuntimeFunctions')) {
+    /**
+     * @internal IDE helper only: exposes directives that collide with PHP keywords.
+     */
+    final class QiqRuntimeFunctions
+    {
+        public static function extends(string $path): void {}
+    }
+}
 
 /* ---------------------------
  * Form Helpers (3.x; keep broad for convenience)

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/highlight/QiqReservedDirectiveAnnotatorTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/highlight/QiqReservedDirectiveAnnotatorTest.kt
@@ -1,5 +1,7 @@
 package io.github.jingu.idea_qiq_plugin.highlight
 
+import io.github.jingu.idea_qiq_plugin.util.QiqUtil
+import io.github.jingu.idea_qiq_plugin.util.ReservedDirectiveSpan
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -8,25 +10,25 @@ class QiqReservedDirectiveAnnotatorTest {
 
     @Test
     fun findsExtendsAtStart() {
-        val span = QiqReservedDirectiveAnnotator.findReservedDirectiveSpan("extends('layout')")
-        assertEquals(QiqReservedDirectiveAnnotator.Span(0, 7), span)
+        val span = QiqUtil.findReservedDirectiveSpan("extends('layout')")
+        assertEquals(ReservedDirectiveSpan(0, 7), span)
     }
 
     @Test
     fun findsExtendsWithWhitespace() {
-        val span = QiqReservedDirectiveAnnotator.findReservedDirectiveSpan("  extends  ('layout')")
-        assertEquals(QiqReservedDirectiveAnnotator.Span(2, 7), span)
+        val span = QiqUtil.findReservedDirectiveSpan("  extends  ('layout')")
+        assertEquals(ReservedDirectiveSpan(2, 7), span)
     }
 
     @Test
     fun ignoresNonDirective() {
-        val span = QiqReservedDirectiveAnnotator.findReservedDirectiveSpan("render('partial')")
+        val span = QiqUtil.findReservedDirectiveSpan("render('partial')")
         assertNull(span)
     }
 
     @Test
     fun requiresParenthesis() {
-        val span = QiqReservedDirectiveAnnotator.findReservedDirectiveSpan("extends 'layout'")
+        val span = QiqUtil.findReservedDirectiveSpan("extends 'layout'")
         assertNull(span)
     }
 }

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/highlight/QiqReservedDirectiveAnnotatorTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/highlight/QiqReservedDirectiveAnnotatorTest.kt
@@ -1,0 +1,32 @@
+package io.github.jingu.idea_qiq_plugin.highlight
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class QiqReservedDirectiveAnnotatorTest {
+
+    @Test
+    fun findsExtendsAtStart() {
+        val span = QiqReservedDirectiveAnnotator.findReservedDirectiveSpan("extends('layout')")
+        assertEquals(QiqReservedDirectiveAnnotator.Span(0, 7), span)
+    }
+
+    @Test
+    fun findsExtendsWithWhitespace() {
+        val span = QiqReservedDirectiveAnnotator.findReservedDirectiveSpan("  extends  ('layout')")
+        assertEquals(QiqReservedDirectiveAnnotator.Span(2, 7), span)
+    }
+
+    @Test
+    fun ignoresNonDirective() {
+        val span = QiqReservedDirectiveAnnotator.findReservedDirectiveSpan("render('partial')")
+        assertNull(span)
+    }
+
+    @Test
+    fun requiresParenthesis() {
+        val span = QiqReservedDirectiveAnnotator.findReservedDirectiveSpan("extends 'layout'")
+        assertNull(span)
+    }
+}


### PR DESCRIPTION
This pull request introduces improved support for handling reserved-word directives (like `extends`) in Qiq templates. The main changes include adding a new annotator for highlighting these directives, updating the PHP runtime stub to expose a helper for such directives, and refining the PHP injection logic to handle them correctly. Tests are also added to ensure the correct identification of reserved directives.

**Highlighting and IDE support improvements:**

* Added a new `QiqReservedDirectiveAnnotator` to detect and highlight reserved-word directives (such as `extends`) in Qiq templates, ensuring they receive appropriate syntax highlighting. [[1]](diffhunk://#diff-b97b404f56c5a5d89f80e9e4fb40d70dbba9da0eb01ae3a313213105528114dfR1-R64) [[2]](diffhunk://#diff-13198d14dd3abf13abd9cb906331ed7d9663fc081757b6845fd5f3c1850b5693R37-R39)
* Introduced tests for `QiqReservedDirectiveAnnotator` to verify correct detection of reserved directives.

**PHP runtime and injection logic updates:**

* Updated the PHP runtime stub by removing the global `extends` function and introducing a `QiqRuntimeFunctions` class with a static `extends` method, providing an IDE-friendly way to reference reserved directives. [[1]](diffhunk://#diff-769789363300476636ed8a837870082b1e8535134de8d84fcf6a69f999427f37L15) [[2]](diffhunk://#diff-769789363300476636ed8a837870082b1e8535134de8d84fcf6a69f999427f37R55-R67)
* Modified the PHP injection logic in `QiqPhpInjector` to detect reserved directives and rewrite them to use the new `QiqRuntimeFunctions::extends` method, ensuring proper code injection and completion. [[1]](diffhunk://#diff-dba9ad2391f5dc40c5f216990208db5482e41e3192b0531069acda76653e5e4bR84-R88) [[2]](diffhunk://#diff-dba9ad2391f5dc40c5f216990208db5482e41e3192b0531069acda76653e5e4bR135-R139) [[3]](diffhunk://#diff-dba9ad2391f5dc40c5f216990208db5482e41e3192b0531069acda76653e5e4bL140-R174)