### PR TITLE
chore: support PhpStorm 2026.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,10 +44,16 @@ configurations.named("testRuntimeOnly") {
 }
 
 intellijPlatform {
+    pluginVerification {
+        ides {
+            ide(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.PhpStorm, "2024.2")
+            ide(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.PhpStorm, "2026.1")
+        }
+    }
     pluginConfiguration {
         name.set("Qiq Templates Support")
         id.set("io.github.jingu.idea-qiq-plugin")
-        version.set("0.4.0")
+        version.set("0.5.0")
         ideaVersion {
             sinceBuild.set("241")
             untilBuild.set("261.*")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,7 @@ intellijPlatform {
         version.set("0.4.0")
         ideaVersion {
             sinceBuild.set("241")
-            untilBuild.set("253.*")
+            untilBuild.set("261.*")
         }
         description.set("Syntax highlighting and simple navigation for Qiq templates")
         vendor {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -70,15 +70,9 @@
     </actions>
     <change-notes><![CDATA[
 <ul>
-  <li><b>HTML-aware Comment Toggle</b>
+  <li><b>PhpStorm 2026.1 Support</b>
     <ul>
-      <li>Lines containing HTML tags with embedded Qiq expressions now wrap in <code><!-- --></code> and comment the expressions safely.</li>
-      <li>Existing comments and blank or whitespace-only lines are detected to avoid double commenting.</li>
-    </ul>
-  </li>
-  <li><b>Reliability Improvements</b>
-    <ul>
-      <li>Added unit tests that exercise the QiqCommenter comment/uncomment round-trip.</li>
+      <li>Extended compatibility to PhpStorm 2026.1 (build 261).</li>
     </ul>
   </li>
 </ul>


### PR DESCRIPTION
## Summary
- `untilBuild` を `253.*` → `261.*` に更新し、PhpStorm 2026.1 (build 261) に対応

## Test plan
- [x] `./gradlew buildPlugin` が成功することを確認
- [x] `./gradlew test` が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)