### PR TITLE
feat: route escape directives through typed runtime stubs

### DIFF
--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjector.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjector.kt
@@ -127,33 +127,47 @@ class QiqPhpInjector : MultiHostInjector, DumbAware {
         var injectionRange = range
 
         if (isPrintLike) {
-            // The parser strips the leading modifier byte (h/a/j/u/c/=) from the host
-            // text and encodes it in the element type instead, so derive the directive
-            // from the element type. Defensive fallback to the first character handles
-            // legacy PSI shapes (text-based kind detection in QiqCodeHost).
-            val escapeMethod = escapeMethodFor(host)
+            // The current parser encodes the escape directive (h/a/j/u/c) in the
+            // element type and the lexer consumes the modifier byte as part of
+            // the opener, so the host text starts with the PHP expression and no
+            // strip is required. For legacy PSI shapes (ESCAPE_CONTENT) or hosts
+            // that reach isPrintLike() via QiqCodeHost's text-based fallback,
+            // the modifier may still be present in the text — in that case we
+            // detect it from the first character and strip it from the injection
+            // range so the inner expression is what gets passed to ::h() etc.
+            val elementTypeMethod = escapeMethodFromElementType(host)
+            val firstChar = trimmedContent.first()
 
-            if (escapeMethod != null) {
-                // Route escape directives through QiqRuntimeFunctions* so that
-                // PhpStorm validates the argument against the PHPDoc signature.
-                // The runtime class is picked based on the qiq/qiq major
-                // version detected in composer.lock: v1 has string-only
-                // signatures, while v2+ accept null|scalar|\Stringable.
-                val runtimeClass = resolveRuntimeClass(host)
-                prefix = "<?= \\$runtimeClass::$escapeMethod("
-                suffix = ") ?>"
-            } else {
-                // {{= ... }} or unclassified print-like host: emit a plain echo tag.
-                if (trimmedContent.first() == '=') {
-                    var newStart = range.startOffset + 1
-                    while (newStart < range.endOffset && raw[newStart].isWhitespace()) {
-                        newStart++
-                    }
-                    if (newStart >= range.endOffset) return null
-                    injectionRange = TextRange(newStart, range.endOffset)
+            when {
+                elementTypeMethod != null -> {
+                    // Modern PSI: parser already stripped the modifier.
+                    val runtimeClass = resolveRuntimeClass(host)
+                    prefix = "<?= \\$runtimeClass::$elementTypeMethod("
+                    suffix = ") ?>"
                 }
-                prefix = "<?= "
-                suffix = " ?>"
+                firstChar in ESCAPE_MODIFIER_CHARS -> {
+                    // Legacy / text-fallback: strip the modifier byte before
+                    // routing through QiqRuntimeFunctions*.
+                    val strippedStart = skipLeadingWhitespace(raw, range.startOffset + 1, range.endOffset)
+                        ?: return null
+                    injectionRange = TextRange(strippedStart, range.endOffset)
+                    val runtimeClass = resolveRuntimeClass(host)
+                    prefix = "<?= \\$runtimeClass::$firstChar("
+                    suffix = ") ?>"
+                }
+                firstChar == '=' -> {
+                    // {{= ... }}: raw echo, strip the `=` and emit a plain echo tag.
+                    val strippedStart = skipLeadingWhitespace(raw, range.startOffset + 1, range.endOffset)
+                        ?: return null
+                    injectionRange = TextRange(strippedStart, range.endOffset)
+                    prefix = "<?= "
+                    suffix = " ?>"
+                }
+                else -> {
+                    // Unclassified print-like host (e.g. bare `{{ $x }}`): plain echo.
+                    prefix = "<?= "
+                    suffix = " ?>"
+                }
             }
         } else {
             val lower = trimmedContent.lowercase(Locale.ROOT)
@@ -177,19 +191,27 @@ class QiqPhpInjector : MultiHostInjector, DumbAware {
         val vf = host.containingFile?.virtualFile ?: return DEFAULT_RUNTIME_CLASS
         val major = QiqSettingsService.getInstance(host.project).resolveQiqMajorVersion(vf)
         val runtimeClass = if (major == 1) STRICT_RUNTIME_CLASS else DEFAULT_RUNTIME_CLASS
-        if (stubSelectionLogged.add(vf.path) && log.isDebugEnabled) {
+        // Guard add() behind isDebugEnabled so stubSelectionLogged does not grow
+        // unboundedly in production where debug logging is off.
+        if (log.isDebugEnabled && stubSelectionLogged.add(vf.path)) {
             log.debug("Qiq stub selection: major=$major, class=$runtimeClass, file=${vf.path}")
         }
         return runtimeClass
     }
 
-    private fun escapeMethodFor(host: QiqCodeHost): Char? = when (host.node.elementType) {
+    private fun escapeMethodFromElementType(host: QiqCodeHost): Char? = when (host.node.elementType) {
         QiqTokenTypes.ESCAPE_H_CONTENT -> 'h'
         QiqTokenTypes.ESCAPE_A_CONTENT -> 'a'
         QiqTokenTypes.ESCAPE_J_CONTENT -> 'j'
         QiqTokenTypes.ESCAPE_U_CONTENT -> 'u'
         QiqTokenTypes.ESCAPE_C_CONTENT -> 'c'
         else -> null
+    }
+
+    private fun skipLeadingWhitespace(raw: String, from: Int, until: Int): Int? {
+        var i = from
+        while (i < until && raw[i].isWhitespace()) i++
+        return if (i >= until) null else i
     }
 
     private fun rewriteReservedDirective(raw: String, range: TextRange): ReservedDirectiveRewrite? {
@@ -228,5 +250,6 @@ class QiqPhpInjector : MultiHostInjector, DumbAware {
     companion object {
         private const val DEFAULT_RUNTIME_CLASS = "QiqRuntimeFunctions"
         private const val STRICT_RUNTIME_CLASS = "QiqRuntimeFunctionsStrict"
+        private val ESCAPE_MODIFIER_CHARS = setOf('h', 'a', 'j', 'u', 'c')
     }
 }

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjector.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjector.kt
@@ -11,8 +11,10 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiLanguageInjectionHost
 import com.intellij.psi.util.PsiTreeUtil
 import com.jetbrains.php.lang.PhpLanguage
+import io.github.jingu.idea_qiq_plugin.lang.QiqTokenTypes
 import io.github.jingu.idea_qiq_plugin.psi.QiqCodeHost
 import io.github.jingu.idea_qiq_plugin.psi.QiqPhpHost
+import io.github.jingu.idea_qiq_plugin.settings.QiqSettingsService
 import io.github.jingu.idea_qiq_plugin.util.QiqUtil
 import java.util.Locale
 
@@ -24,6 +26,13 @@ import java.util.Locale
 class QiqPhpInjector : MultiHostInjector, DumbAware {
 
     private val log = Logger.getInstance(QiqPhpInjector::class.java)
+
+    // Per-file dedup: emit the resolved stub selection once per file so that
+    // users (and bug reports) can verify which QiqRuntimeFunctions* class is
+    // being injected without scanning thousands of duplicate lines. Logged at
+    // debug level — enable `io.github.jingu.idea_qiq_plugin.inject.QiqPhpInjector`
+    // in Help > Diagnostic Tools > Debug Log Settings to surface it.
+    private val stubSelectionLogged = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
 
     private data class InjectionPlan(
         val modificationStamp: Long,
@@ -118,18 +127,34 @@ class QiqPhpInjector : MultiHostInjector, DumbAware {
         var injectionRange = range
 
         if (isPrintLike) {
-            val firstChar = trimmedContent.first()
-            if (firstChar in setOf('=', 'h', 'j', 'a', 'u', 'c')) {
-                var newStart = range.startOffset + 1
-                while (newStart < range.endOffset && raw[newStart].isWhitespace()) {
-                    newStart++
-                }
-                if (newStart >= range.endOffset) return null
-                injectionRange = TextRange(newStart, range.endOffset)
-            }
+            // The parser strips the leading modifier byte (h/a/j/u/c/=) from the host
+            // text and encodes it in the element type instead, so derive the directive
+            // from the element type. Defensive fallback to the first character handles
+            // legacy PSI shapes (text-based kind detection in QiqCodeHost).
+            val escapeMethod = escapeMethodFor(host)
 
-            prefix = "<?= "
-            suffix = " ?>"
+            if (escapeMethod != null) {
+                // Route escape directives through QiqRuntimeFunctions* so that
+                // PhpStorm validates the argument against the PHPDoc signature.
+                // The runtime class is picked based on the qiq/qiq major
+                // version detected in composer.lock: v1 has string-only
+                // signatures, while v2+ accept null|scalar|\Stringable.
+                val runtimeClass = resolveRuntimeClass(host)
+                prefix = "<?= \\$runtimeClass::$escapeMethod("
+                suffix = ") ?>"
+            } else {
+                // {{= ... }} or unclassified print-like host: emit a plain echo tag.
+                if (trimmedContent.first() == '=') {
+                    var newStart = range.startOffset + 1
+                    while (newStart < range.endOffset && raw[newStart].isWhitespace()) {
+                        newStart++
+                    }
+                    if (newStart >= range.endOffset) return null
+                    injectionRange = TextRange(newStart, range.endOffset)
+                }
+                prefix = "<?= "
+                suffix = " ?>"
+            }
         } else {
             val lower = trimmedContent.lowercase(Locale.ROOT)
 
@@ -146,6 +171,25 @@ class QiqPhpInjector : MultiHostInjector, DumbAware {
         }
 
         return PhpInjectionFragment(host, injectionRange, prefix, suffix)
+    }
+
+    private fun resolveRuntimeClass(host: QiqCodeHost): String {
+        val vf = host.containingFile?.virtualFile ?: return DEFAULT_RUNTIME_CLASS
+        val major = QiqSettingsService.getInstance(host.project).resolveQiqMajorVersion(vf)
+        val runtimeClass = if (major == 1) STRICT_RUNTIME_CLASS else DEFAULT_RUNTIME_CLASS
+        if (stubSelectionLogged.add(vf.path) && log.isDebugEnabled) {
+            log.debug("Qiq stub selection: major=$major, class=$runtimeClass, file=${vf.path}")
+        }
+        return runtimeClass
+    }
+
+    private fun escapeMethodFor(host: QiqCodeHost): Char? = when (host.node.elementType) {
+        QiqTokenTypes.ESCAPE_H_CONTENT -> 'h'
+        QiqTokenTypes.ESCAPE_A_CONTENT -> 'a'
+        QiqTokenTypes.ESCAPE_J_CONTENT -> 'j'
+        QiqTokenTypes.ESCAPE_U_CONTENT -> 'u'
+        QiqTokenTypes.ESCAPE_C_CONTENT -> 'c'
+        else -> null
     }
 
     private fun rewriteReservedDirective(raw: String, range: TextRange): ReservedDirectiveRewrite? {
@@ -180,4 +224,9 @@ class QiqPhpInjector : MultiHostInjector, DumbAware {
 
     override fun elementsToInjectIn(): List<Class<out PsiElement>> =
         listOf(QiqCodeHost::class.java, QiqPhpHost::class.java)
+
+    companion object {
+        private const val DEFAULT_RUNTIME_CLASS = "QiqRuntimeFunctions"
+        private const val STRICT_RUNTIME_CLASS = "QiqRuntimeFunctionsStrict"
+    }
 }

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/lang/QiqParserDefinition.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/lang/QiqParserDefinition.kt
@@ -104,9 +104,17 @@ private enum class QiqBlockKind(
         QiqTokenTypes.RBRACE_EQ,
         QiqTokenTypes.CLOSE_EQ
     ),
-    ESCAPE_GENERIC(
-        QiqTokenTypes.ESCAPE_CONTENT,
+    ESCAPE_ATTR(
+        QiqTokenTypes.ESCAPE_A_CONTENT,
+        QiqTokenTypes.RBRACEA,
         QiqTokenTypes.RBRACEC,
+        QiqTokenTypes.CLOSE_A,
+        QiqTokenTypes.CLOSE_C
+    ),
+    ESCAPE_CSS(
+        QiqTokenTypes.ESCAPE_C_CONTENT,
+        QiqTokenTypes.RBRACEC,
+        QiqTokenTypes.RBRACEA,
         QiqTokenTypes.CLOSE_C,
         QiqTokenTypes.CLOSE_A
     ),
@@ -136,12 +144,12 @@ private fun IElementType?.blockKind(): QiqBlockKind? = when (this) {
     QiqTokenTypes.RAW_OPEN,
     QiqTokenTypes.LBRACE_EQ,
     QiqTokenTypes.OPEN_EQ -> QiqBlockKind.RAW
-    QiqTokenTypes.ESCAPE_C_OPEN,
     QiqTokenTypes.ESCAPE_A_OPEN,
-    QiqTokenTypes.LBRACEC,
     QiqTokenTypes.LBRACEA,
-    QiqTokenTypes.OPEN_C,
-    QiqTokenTypes.OPEN_A -> QiqBlockKind.ESCAPE_GENERIC
+    QiqTokenTypes.OPEN_A -> QiqBlockKind.ESCAPE_ATTR
+    QiqTokenTypes.ESCAPE_C_OPEN,
+    QiqTokenTypes.LBRACEC,
+    QiqTokenTypes.OPEN_C -> QiqBlockKind.ESCAPE_CSS
     QiqTokenTypes.ESCAPE_H_OPEN,
     QiqTokenTypes.LBRACEH,
     QiqTokenTypes.OPEN_H -> QiqBlockKind.ESCAPE_HTML

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/settings/QiqSettingService.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/settings/QiqSettingService.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
 import io.github.jingu.idea_qiq_plugin.util.QiqComposerVersionResolver
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.max
 
 @Service(Service.Level.PROJECT)
@@ -81,7 +82,10 @@ class QiqSettingsService(private val project: Project) : PersistentStateComponen
     }
 
     private data class ComposerLockEntry(val modificationStamp: Long, val majorVersion: Int)
-    private val composerLockCache = mutableMapOf<String, ComposerLockEntry>()
+    // ConcurrentHashMap: resolveQiqMajorVersion may be invoked from parallel
+    // ReadActions (e.g. concurrent PSI injection across files), so the cache
+    // backing store must tolerate concurrent put/get without map corruption.
+    private val composerLockCache = ConcurrentHashMap<String, ComposerLockEntry>()
 
     // ---- simple cache ----
 

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/settings/QiqSettingService.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/settings/QiqSettingService.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
+import io.github.jingu.idea_qiq_plugin.util.QiqComposerVersionResolver
 import java.io.File
 import kotlin.math.max
 
@@ -33,6 +34,7 @@ class QiqSettingsService(private val project: Project) : PersistentStateComponen
     override fun loadState(s: State) { state = s }
 
     companion object {
+        const val DEFAULT_MAJOR_VERSION = 3
         fun getInstance(project: Project) = project.getService(QiqSettingsService::class.java)
     }
 
@@ -49,6 +51,37 @@ class QiqSettingsService(private val project: Project) : PersistentStateComponen
         cache(contextFile, withFallback)
         return withFallback
     }
+
+    /**
+     * Returns the qiq/qiq major version declared in composer.lock for the
+     * content root that owns [contextFile]. Falls back to 3 when the lock
+     * file is missing, the package is not present, or the version string is
+     * unparseable (e.g. `dev-main`). The plugin uses this to decide which
+     * QiqRuntimeFunctions* stub class to route escape directives through:
+     *   - v1 → QiqRuntimeFunctionsStrict (string-only signatures)
+     *   - v2+ → QiqRuntimeFunctions (null|scalar|\Stringable signatures)
+     */
+    fun resolveQiqMajorVersion(contextFile: VirtualFile): Int {
+        val lockFile = findComposerLock(contextFile) ?: return DEFAULT_MAJOR_VERSION
+        val cached = composerLockCache[lockFile.path]
+        if (cached != null && cached.modificationStamp == lockFile.modificationStamp) {
+            return cached.majorVersion
+        }
+        val text = runCatching { VfsUtilCore.loadText(lockFile) }.getOrNull()
+            ?: return DEFAULT_MAJOR_VERSION
+        val parsed = QiqComposerVersionResolver.parseMajorVersion(text) ?: DEFAULT_MAJOR_VERSION
+        composerLockCache[lockFile.path] = ComposerLockEntry(lockFile.modificationStamp, parsed)
+        return parsed
+    }
+
+    private fun findComposerLock(contextFile: VirtualFile): VirtualFile? {
+        val contentRoot = ProjectFileIndex.getInstance(project).getContentRootForFile(contextFile)
+            ?: return null
+        return contentRoot.findChild("composer.lock")?.takeIf { it.isValid && !it.isDirectory }
+    }
+
+    private data class ComposerLockEntry(val modificationStamp: Long, val majorVersion: Int)
+    private val composerLockCache = mutableMapOf<String, ComposerLockEntry>()
 
     // ---- simple cache ----
 

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/settings/QiqSettingService.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/settings/QiqSettingService.kt
@@ -90,7 +90,9 @@ class QiqSettingsService(private val project: Project) : PersistentStateComponen
     // ---- simple cache ----
 
     private data class CacheKey(val path: String)
-    private val cacheMap = mutableMapOf<CacheKey, List<VirtualFile>>()
+    // Same rationale as composerLockCache: resolveTemplateRoots is called
+    // from completion/navigation contributors running on parallel ReadActions.
+    private val cacheMap = ConcurrentHashMap<CacheKey, List<VirtualFile>>()
 
     private fun getCached(contextFile: VirtualFile): List<VirtualFile> =
         cacheMap[CacheKey(contextFile.path)] ?: emptyList()

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/util/QiqComposerVersionResolver.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/util/QiqComposerVersionResolver.kt
@@ -1,0 +1,80 @@
+package io.github.jingu.idea_qiq_plugin.util
+
+/**
+ * Parses a `composer.lock` payload to find the major version of `qiq/qiq`.
+ *
+ * Kept as a pure function (no IntelliJ Platform deps) so the parsing logic
+ * is unit-testable without spinning up a fixture project.
+ *
+ * The lock file is generated machine-output JSON, so a single tolerant regex
+ * is sufficient. We avoid pulling in a JSON library to keep plugin
+ * dependencies minimal.
+ */
+object QiqComposerVersionResolver {
+
+    // The Composer package name is "qiq/qiq" (not "qiqphp/qiq", which is the
+    // GitHub org/repo). Verified across Qiq 1.x, 2.x and 3.x composer.json.
+    private const val PACKAGE_NAME = "qiq/qiq"
+
+    /**
+     * Returns the major version (e.g. 1, 2, 3) of qiq/qiq declared in the
+     * given composer.lock content, or null when the package is not present
+     * or the version string cannot be parsed (e.g. `dev-main`, `dev-master`).
+     */
+    fun parseMajorVersion(lockContent: String): Int? {
+        val nameIndex = findPackageNameIndex(lockContent) ?: return null
+        val version = findVersionAfter(lockContent, nameIndex) ?: return null
+        return extractMajor(version)
+    }
+
+    private fun findPackageNameIndex(content: String): Int? {
+        // Match `"name": "qiq/qiq"` with flexible whitespace.
+        val nameRegex = Regex(
+            """"name"\s*:\s*"${Regex.escape(PACKAGE_NAME)}"""",
+        )
+        return nameRegex.find(content)?.range?.first
+    }
+
+    private fun findVersionAfter(content: String, fromIndex: Int): String? {
+        // composer.lock package entries are JSON objects; we walk forward from
+        // the matched "name" key and grab the next "version" field within the
+        // same object (i.e. before the closing `}` of that entry).
+        val objectEnd = findObjectEnd(content, fromIndex) ?: content.length
+        val slice = content.substring(fromIndex, objectEnd)
+        val versionRegex = Regex(""""version"\s*:\s*"([^"]+)"""")
+        return versionRegex.find(slice)?.groupValues?.get(1)
+    }
+
+    private fun findObjectEnd(content: String, fromIndex: Int): Int? {
+        // Walk forward respecting nesting depth and quoted strings.
+        var depth = 1 // we're already inside the object that holds "name"
+        var i = fromIndex
+        var inString = false
+        var escaped = false
+        while (i < content.length) {
+            val c = content[i]
+            when {
+                escaped -> escaped = false
+                inString && c == '\\' -> escaped = true
+                c == '"' -> inString = !inString
+                inString -> { /* skip */ }
+                c == '{' -> depth++
+                c == '}' -> {
+                    depth--
+                    if (depth == 0) return i
+                }
+            }
+            i++
+        }
+        return null
+    }
+
+    private fun extractMajor(version: String): Int? {
+        // Strip a leading `v` (e.g. "v3.0.1") and take the prefix up to the
+        // first dot. Reject anything that does not parse as an integer (e.g.
+        // "dev-main", "3.x-dev").
+        val trimmed = version.trim().removePrefix("v")
+        val head = trimmed.substringBefore('.')
+        return head.toIntOrNull()
+    }
+}

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/util/QiqComposerVersionResolver.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/util/QiqComposerVersionResolver.kt
@@ -71,8 +71,10 @@ object QiqComposerVersionResolver {
 
     private fun extractMajor(version: String): Int? {
         // Strip a leading `v` (e.g. "v3.0.1") and take the prefix up to the
-        // first dot. Reject anything that does not parse as an integer (e.g.
-        // "dev-main", "3.x-dev").
+        // first dot, then parse as Int. This intentionally accepts floating
+        // dev branches like "3.x-dev" (head "3" → 3) so users tracking
+        // unreleased majors still get the right stub. Pure "dev-main" /
+        // "dev-master" yield null because the head is not an integer.
         val trimmed = version.trim().removePrefix("v")
         val head = trimmed.substringBefore('.')
         return head.toIntOrNull()

--- a/src/main/resources/library/qiq_runtime.php
+++ b/src/main/resources/library/qiq_runtime.php
@@ -57,11 +57,56 @@ function metaHttp($httpEquiv, $content, array $attrs = []): string { return ''; 
  * ------------------------------------------------------ */
 if (!class_exists('QiqRuntimeFunctions')) {
     /**
-     * @internal IDE helper only: exposes directives that collide with PHP keywords.
+     * @internal IDE helper only: surfaces Qiq compiler-generated calls so PhpStorm
+     * inspections can validate them.
+     *
+     * - `extends` is exposed because the directive collides with a PHP keyword.
+     * - `h/a/j/u/c` mirror Qiq\Template::h()/a()/j()/u()/c() but as static methods,
+     *   carrying the same PHPDoc constraints. Qiq compiles `{{h $x }}` into
+     *   `<?= $this->h($x) ?>`, but $this is untyped inside template scope so the
+     *   plugin routes escape directives through this helper to make the
+     *   `null|scalar|\Stringable` signature visible to inspections.
      */
     final class QiqRuntimeFunctions
     {
         public static function extends(string $path): void {}
+
+        /** @param null|scalar|\Stringable $raw */
+        public static function h(mixed $raw): string { return ''; }
+
+        /** @param null|scalar|\Stringable|array<null|scalar|\Stringable|array<null|scalar|\Stringable>> $raw */
+        public static function a(mixed $raw): string { return ''; }
+
+        /** @param null|scalar|\Stringable $raw */
+        public static function j(mixed $raw): string { return ''; }
+
+        /** @param null|scalar|\Stringable $raw */
+        public static function u(mixed $raw): string { return ''; }
+
+        /** @param null|scalar|\Stringable $raw */
+        public static function c(mixed $raw): string { return ''; }
+    }
+}
+
+if (!class_exists('QiqRuntimeFunctionsStrict')) {
+    /**
+     * @internal IDE helper only: mirrors Qiq 1.x Escape signatures which
+     * accept `string` (and `string|array` for `a()`) only. Used by the
+     * plugin when composer.lock pins qiq/qiq to ^1.0; v2.x/v3.x relax
+     * the signature to `mixed` and use {@see QiqRuntimeFunctions}.
+     */
+    final class QiqRuntimeFunctionsStrict
+    {
+        public static function h(string $raw): string { return ''; }
+
+        /** @param string|array<array-key, string|array> $raw */
+        public static function a(string|array $raw): string { return ''; }
+
+        public static function j(string $raw): string { return ''; }
+
+        public static function u(string $raw): string { return ''; }
+
+        public static function c(string $raw): string { return ''; }
     }
 }
 

--- a/src/main/resources/library/qiq_runtime.php
+++ b/src/main/resources/library/qiq_runtime.php
@@ -71,20 +71,24 @@ if (!class_exists('QiqRuntimeFunctions')) {
     {
         public static function extends(string $path): void {}
 
+        // Parameters are typed via PHPDoc only; the native `mixed` keyword
+        // (PHP 8.0+) would break stub parsing for projects whose Language
+        // Level is set to PHP 7.x.
+
         /** @param null|scalar|\Stringable $raw */
-        public static function h(mixed $raw): string { return ''; }
+        public static function h($raw): string { return ''; }
 
         /** @param null|scalar|\Stringable|array<null|scalar|\Stringable|array<null|scalar|\Stringable>> $raw */
-        public static function a(mixed $raw): string { return ''; }
+        public static function a($raw): string { return ''; }
 
         /** @param null|scalar|\Stringable $raw */
-        public static function j(mixed $raw): string { return ''; }
+        public static function j($raw): string { return ''; }
 
         /** @param null|scalar|\Stringable $raw */
-        public static function u(mixed $raw): string { return ''; }
+        public static function u($raw): string { return ''; }
 
         /** @param null|scalar|\Stringable $raw */
-        public static function c(mixed $raw): string { return ''; }
+        public static function c($raw): string { return ''; }
     }
 }
 
@@ -99,8 +103,12 @@ if (!class_exists('QiqRuntimeFunctionsStrict')) {
     {
         public static function h(string $raw): string { return ''; }
 
+        // a() accepts `string|array` in Qiq 1.x. The union type is PHP 8.0+
+        // syntax, so it is expressed via PHPDoc to keep the stub parseable
+        // under PHP 7.x language levels.
+
         /** @param string|array<array-key, string|array> $raw */
-        public static function a(string|array $raw): string { return ''; }
+        public static function a($raw): string { return ''; }
 
         public static function j(string $raw): string { return ''; }
 

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjectorTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/inject/QiqPhpInjectorTest.kt
@@ -36,20 +36,19 @@ class QiqPhpInjectorTest {
 
     @Test
     fun aggregatesAllFragmentsIntoSinglePhpStream(project: Project) {
-        val psiFile = createQiqFile(
-            project,
-            """
-            {{ foreach (${ '$'}items as ${ '$'}item): }}
-            <li>{{h ${ '$'}item->name }}</li>
-            {{ endforeach }}
-            """.trimIndent()
-        )
-
         val expected = """
-            <?php foreach (${ '$'}items as ${ '$'}item): ?><?= ${ '$'}item->name ?><?php endforeach; ?>
+            <?php foreach (${ '$'}items as ${ '$'}item): ?><?= \QiqRuntimeFunctions::h(${ '$'}item->name) ?><?php endforeach; ?>
             """.trimIndent()
 
         ApplicationManager.getApplication().runReadAction {
+            val psiFile = createQiqFile(
+                project,
+                """
+                {{ foreach (${ '$'}items as ${ '$'}item): }}
+                <li>{{h ${ '$'}item->name }}</li>
+                {{ endforeach }}
+                """.trimIndent()
+            )
             val hosts = PsiTreeUtil.collectElementsOfType(psiFile, QiqCodeHost::class.java).toList()
             assertEquals(3, hosts.size, "Unexpected number of QiqCodeHost elements")
 
@@ -76,10 +75,52 @@ class QiqPhpInjectorTest {
         }
     }
 
-    private fun createQiqFile(project: Project, text: String): PsiFile {
-        return WriteAction.compute<PsiFile, RuntimeException> {
-            PsiFileFactory.getInstance(project).createFileFromText("sample.qiq", QiqFileType, text)
+    @Test
+    fun escapeDirectivesAreRoutedThroughRuntimeFunctions(project: Project) {
+        val cases = mapOf(
+            "h" to "<?= \\QiqRuntimeFunctions::h(",
+            "a" to "<?= \\QiqRuntimeFunctions::a(",
+            "j" to "<?= \\QiqRuntimeFunctions::j(",
+            "u" to "<?= \\QiqRuntimeFunctions::u(",
+            "c" to "<?= \\QiqRuntimeFunctions::c(",
+        )
+
+        ApplicationManager.getApplication().runReadAction {
+            for ((modifier, expectedPrefix) in cases) {
+                val psiFile = createQiqFile(project, "{{$modifier \$value }}")
+                val host = PsiTreeUtil.collectElementsOfType(psiFile, QiqCodeHost::class.java).single()
+
+                val registrar = RecordingRegistrar()
+                injector.getLanguagesToInject(registrar, host)
+
+                val call = registrar.calls.single { it.language == PhpLanguage.INSTANCE }
+                assertEquals(expectedPrefix, call.prefix, "Wrong prefix for {{$modifier ... }}")
+                assertEquals(") ?>", call.suffix, "Wrong suffix for {{$modifier ... }}")
+            }
         }
+    }
+
+    @Test
+    fun rawDirectiveUsesPlainEchoTag(project: Project) {
+        ApplicationManager.getApplication().runReadAction {
+            val psiFile = createQiqFile(project, "{{= \$value }}")
+            val host = PsiTreeUtil.collectElementsOfType(psiFile, QiqCodeHost::class.java).single()
+
+            val registrar = RecordingRegistrar()
+            injector.getLanguagesToInject(registrar, host)
+
+            val call = registrar.calls.single { it.language == PhpLanguage.INSTANCE }
+            assertEquals("<?= ", call.prefix, "{{= ... }} should keep the plain echo tag")
+            assertEquals(" ?>", call.suffix)
+        }
+    }
+
+    private fun createQiqFile(project: Project, text: String): PsiFile {
+        // In-memory PSI construction: no write lock required, and wrapping in
+        // WriteAction throws if the caller is already inside a ReadAction (which
+        // some test extensions enter implicitly).
+        return PsiFileFactory.getInstance(project)
+            .createFileFromText("sample.qiq", QiqFileType, text)
     }
 
     private fun assembleInjectedText(calls: List<RecordedCall>): String {

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/util/QiqComposerVersionResolverTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/util/QiqComposerVersionResolverTest.kt
@@ -1,0 +1,107 @@
+package io.github.jingu.idea_qiq_plugin.util
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class QiqComposerVersionResolverTest {
+
+    @Test
+    fun parsesMajorVersionFromTaggedRelease() {
+        val lock = """
+            {
+                "packages": [
+                    {
+                        "name": "qiq/qiq",
+                        "version": "3.0.1",
+                        "source": {}
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        assertEquals(3, QiqComposerVersionResolver.parseMajorVersion(lock))
+    }
+
+    @Test
+    fun parsesQiqOneEvenWhenSurroundedByOtherPackages() {
+        val lock = """
+            {
+                "packages": [
+                    {
+                        "name": "psr/log",
+                        "version": "2.0.0"
+                    },
+                    {
+                        "name": "qiq/qiq",
+                        "version": "1.1.1"
+                    },
+                    {
+                        "name": "laminas/laminas-escaper",
+                        "version": "2.13.0"
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        assertEquals(1, QiqComposerVersionResolver.parseMajorVersion(lock))
+    }
+
+    @Test
+    fun stripsLeadingVPrefix() {
+        val lock = """
+            { "packages": [ { "name": "qiq/qiq", "version": "v2.1.0" } ] }
+        """.trimIndent()
+
+        assertEquals(2, QiqComposerVersionResolver.parseMajorVersion(lock))
+    }
+
+    @Test
+    fun returnsNullForUnknownPackage() {
+        val lock = """
+            { "packages": [ { "name": "psr/log", "version": "2.0.0" } ] }
+        """.trimIndent()
+
+        assertNull(QiqComposerVersionResolver.parseMajorVersion(lock))
+    }
+
+    @Test
+    fun returnsNullForDevBranchVersion() {
+        val lock = """
+            { "packages": [ { "name": "qiq/qiq", "version": "dev-main" } ] }
+        """.trimIndent()
+
+        assertNull(QiqComposerVersionResolver.parseMajorVersion(lock))
+    }
+
+    @Test
+    fun returnsNullForXDevSuffix() {
+        val lock = """
+            { "packages": [ { "name": "qiq/qiq", "version": "3.x-dev" } ] }
+        """.trimIndent()
+
+        // "3.x-dev" → head before '.' is "3", which is a valid Int — we want
+        // this to succeed so that floating dev branches still pick the right
+        // major. Adjust expectation if behaviour changes.
+        assertEquals(3, QiqComposerVersionResolver.parseMajorVersion(lock))
+    }
+
+    @Test
+    fun handlesVersionFieldBeforeName() {
+        // Defensive: some lock files may emit "version" before "name" within
+        // an entry. We currently anchor on the "name" field then look forward,
+        // so this case returns null. Documented as a known limitation.
+        val lock = """
+            {
+                "packages": [
+                    {
+                        "version": "3.0.1",
+                        "name": "qiq/qiq"
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        assertNull(QiqComposerVersionResolver.parseMajorVersion(lock))
+    }
+}


### PR DESCRIPTION
## Summary

Inject Qiq escape directives `{{h/a/j/u/c X }}` as `<?= \QiqRuntimeFunctions[Strict]::X(value) ?>` instead of a plain `<?= X ?>`, so PhpStorm validates the argument against the helper's signature. The strict vs. relaxed stub class is selected per project from `composer.lock`.

## Behavior changes

### Newly detected misuses
- `{{h [...] }}` — array passed where `string` is expected
- `{{h $obj }}` / `{{a $obj }}` — object without `__toString`
- `{{c $array }}` — proves the split of `ESCAPE_GENERIC` (see below); previously `{{a }}` and `{{c }}` shared one element type, so `{{c }}` accidentally inherited `{{a }}`'s `string|array` signature

### Stub selection rule
- `qiq/qiq` `^1.x` → `QiqRuntimeFunctionsStrict` (`string` / `string|array` signatures)
- `qiq/qiq` `^2.x` / `^3.x` → `QiqRuntimeFunctions` (`null|scalar|\Stringable`)
- No lock file / unparseable version → falls back to v3 (relaxed)

### Not detected (PHP language limitation)
- `{{h true }}`, `{{h 123 }}`, `{{h null }}` — implicit scalar→string cast is allowed by PHP unless the caller declares `strict_types=1`. This matches Qiq's own `Escape.php`, which has no `strict_types` declaration. A follow-up PR will add an opt-in **Strict Types** setting that injects `declare(strict_types=1)` into the generated PHP.

## Implementation notes

- New parser split: `ESCAPE_GENERIC` → `ESCAPE_ATTR` + `ESCAPE_CSS`, producing distinct `ESCAPE_A_CONTENT` and `ESCAPE_C_CONTENT` PSI element types.
- New `QiqComposerVersionResolver`: pure (no IntelliJ Platform deps) regex-based composer.lock parser, kept unit-testable; result is cached per `composer.lock` modification stamp.
- New `QiqSettingsService.resolveQiqMajorVersion(VirtualFile)` exposes the parsed major version.
- Escape routing in `QiqPhpInjector` is structured into four explicit cases: (a) element-type match — modern PSI, no strip; (b) text-modifier match — legacy / fallback PSI, strip modifier byte; (c) `{{= }}` raw echo, strip `=`; (d) bare print-like host.
- Per-file dedup of debug-log "Qiq stub selection" line, guarded behind `isDebugEnabled` so the dedup set does not grow in production.
- `composerLockCache` and `cacheMap` in `QiqSettingsService` are both `ConcurrentHashMap` to tolerate parallel ReadActions.

## Review history

- **Copilot review** (commit 2d9d34b): 3 items — misleading comment in `extractMajor`, `composerLockCache` thread safety, and PHP 8+ syntax in stub file — addressed in 6ca1f72 / 341cd98.
- **Self-review** after Copilot pass uncovered a regression risk where escape directives reaching `isPrintLike()` via the text-based fallback would leave the leading modifier byte in the injected PHP. Hardened in 834e0b6 along with the debug-log dedup and the misleading comment.

## Test plan

- [x] `./gradlew test` — green, with new `QiqComposerVersionResolverTest` (7 cases) and `QiqPhpInjectorTest::{escapeDirectivesAreRoutedThroughRuntimeFunctions, rawDirectiveUsesPlainEchoTag}`
- [x] `./gradlew buildPlugin` — produces a valid distribution
- [x] Real-project verification on Qiq 1.x (Hpplus.Spur) via PhpStorm MCP:
  - `{{h <array> }}` → warning `string but array`
  - `{{h <stdClass> }}` → warning `string but stdClass`
  - `{{a <array> }}` → no warning (array allowed)
  - `{{a <stdClass> }}` → warning showing the strict signature `array[]|string|string[]`
  - `{{c <array> }}` → warning (confirms `{{a }}` / `{{c }}` split)
  - `{{= <array> }}` → still warns via the native `<?= ?>` path
  - Property completion and typo detection work in `{{h $obj->... }}` when `$obj` is concretely assigned in a leading `<?php ?>` block

## Out of scope (planned follow-ups)

- **Strict Types setting**: opt-in `declare(strict_types=1)` injection to also catch `{{h <bool/int/null literal> }}`.
- **Rename refactoring propagation**: PSI hosts (`QiqCodeHost` / `QiqPhpHost`) have a no-op `updateText`, so renames performed on a PHP symbol do not rewrite Qiq template references even though inspections do follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)