### PR TITLE
feat: propagate refactorings into Qiq host text

### DIFF
--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/psi/QiqCodeHost.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/psi/QiqCodeHost.kt
@@ -2,9 +2,10 @@ package io.github.jingu.idea_qiq_plugin.psi
 
 import com.intellij.extapi.psi.ASTWrapperPsiElement
 import com.intellij.lang.ASTNode
-import com.intellij.psi.PsiLanguageInjectionHost
-import com.intellij.psi.LiteralTextEscaper
 import com.intellij.openapi.util.TextRange
+import com.intellij.psi.ElementManipulators
+import com.intellij.psi.LiteralTextEscaper
+import com.intellij.psi.PsiLanguageInjectionHost
 import io.github.jingu.idea_qiq_plugin.lang.QiqTokenTypes
 
 class QiqCodeHost(node: ASTNode) : ASTWrapperPsiElement(node), PsiLanguageInjectionHost {
@@ -40,7 +41,8 @@ class QiqCodeHost(node: ASTNode) : ASTWrapperPsiElement(node), PsiLanguageInject
 
     override fun isValidHost(): Boolean = true
 
-    override fun updateText(text: String): PsiLanguageInjectionHost = this
+    override fun updateText(text: String): PsiLanguageInjectionHost =
+        ElementManipulators.handleContentChange(this, text)
 
     override fun createLiteralTextEscaper(): LiteralTextEscaper<QiqCodeHost> =
         object : LiteralTextEscaper<QiqCodeHost>(this) {

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/psi/QiqHostManipulators.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/psi/QiqHostManipulators.kt
@@ -1,0 +1,81 @@
+package io.github.jingu.idea_qiq_plugin.psi
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.AbstractElementManipulator
+import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.tree.IElementType
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.util.IncorrectOperationException
+import io.github.jingu.idea_qiq_plugin.lang.QiqFileType
+import io.github.jingu.idea_qiq_plugin.lang.QiqTokenTypes
+
+/**
+ * Lets refactorings (Rename, Move, etc.) propagate edits made inside the
+ * injected PHP back to the Qiq host text. Without this, IntelliJ would find
+ * the references in the injected fragment but silently drop the rewrite
+ * because PsiLanguageInjectionHost.updateText returns the original host
+ * unchanged.
+ *
+ * Strategy: wrap the new text in a parseable Qiq snippet derived from the
+ * host's element type (e.g. ESCAPE_H_CONTENT → `{{h NEW }}`), re-parse it,
+ * locate the matching host in the synthetic tree, then graft its AST
+ * children into the original host node. The host instance itself is
+ * preserved so callers that already hold a reference keep working.
+ */
+class QiqCodeHostManipulator : AbstractElementManipulator<QiqCodeHost>() {
+    override fun handleContentChange(
+        element: QiqCodeHost,
+        range: TextRange,
+        newContent: String,
+    ): QiqCodeHost {
+        val newHostText = range.replace(element.text, newContent)
+        val snippet = wrapForElementType(element.node.elementType, newHostText)
+        val replacement = reparseHost(element, snippet, element.node.elementType)
+        element.node.replaceAllChildrenToChildrenOf(replacement.node)
+        return element
+    }
+
+    private fun reparseHost(
+        anchor: QiqCodeHost,
+        snippet: String,
+        expectedType: IElementType,
+    ): QiqCodeHost {
+        val tempFile = PsiFileFactory.getInstance(anchor.project)
+            .createFileFromText("_qiq_rename.qiq", QiqFileType, snippet)
+        return PsiTreeUtil.collectElementsOfType(tempFile, QiqCodeHost::class.java)
+            .firstOrNull { it.node.elementType == expectedType }
+            ?: throw IncorrectOperationException(
+                "Failed to re-parse Qiq host (type=$expectedType, snippet=$snippet)",
+            )
+    }
+
+    private fun wrapForElementType(type: IElementType, text: String): String = when (type) {
+        QiqTokenTypes.ESCAPE_H_CONTENT -> "{{h$text}}"
+        QiqTokenTypes.ESCAPE_A_CONTENT -> "{{a$text}}"
+        QiqTokenTypes.ESCAPE_J_CONTENT -> "{{j$text}}"
+        QiqTokenTypes.ESCAPE_U_CONTENT -> "{{u$text}}"
+        QiqTokenTypes.ESCAPE_C_CONTENT -> "{{c$text}}"
+        QiqTokenTypes.ESCAPE_CONTENT -> "{{h$text}}"
+        QiqTokenTypes.RAW_CONTENT -> "{{=$text}}"
+        else -> "{{$text}}"
+    }
+}
+
+class QiqPhpHostManipulator : AbstractElementManipulator<QiqPhpHost>() {
+    override fun handleContentChange(
+        element: QiqPhpHost,
+        range: TextRange,
+        newContent: String,
+    ): QiqPhpHost {
+        val newHostText = range.replace(element.text, newContent)
+        val snippet = "<?php$newHostText?>"
+        val tempFile = PsiFileFactory.getInstance(element.project)
+            .createFileFromText("_qiq_php_rename.qiq", QiqFileType, snippet)
+        val replacement = PsiTreeUtil.findChildOfType(tempFile, QiqPhpHost::class.java)
+            ?: throw IncorrectOperationException(
+                "Failed to re-parse Qiq PHP host (snippet=$snippet)",
+            )
+        element.node.replaceAllChildrenToChildrenOf(replacement.node)
+        return element
+    }
+}

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/psi/QiqPhpHost.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/psi/QiqPhpHost.kt
@@ -2,15 +2,17 @@ package io.github.jingu.idea_qiq_plugin.psi
 
 import com.intellij.extapi.psi.ASTWrapperPsiElement
 import com.intellij.lang.ASTNode
-import com.intellij.psi.PsiLanguageInjectionHost
-import com.intellij.psi.LiteralTextEscaper
 import com.intellij.openapi.util.TextRange
+import com.intellij.psi.ElementManipulators
+import com.intellij.psi.LiteralTextEscaper
+import com.intellij.psi.PsiLanguageInjectionHost
 
 class QiqPhpHost(node: ASTNode) : ASTWrapperPsiElement(node), PsiLanguageInjectionHost {
 
     override fun isValidHost(): Boolean = true
 
-    override fun updateText(text: String): PsiLanguageInjectionHost = this
+    override fun updateText(text: String): PsiLanguageInjectionHost =
+        ElementManipulators.handleContentChange(this, text)
 
     override fun createLiteralTextEscaper(): LiteralTextEscaper<QiqPhpHost> =
         object : LiteralTextEscaper<QiqPhpHost>(this) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -53,6 +53,15 @@
 
         <psi.referenceContributor
                 implementation="io.github.jingu.idea_qiq_plugin.navigation.QiqReferenceContributor"/>
+
+        <!-- ElementManipulators: required for refactorings (Rename, Move, etc.)
+             to propagate edits made inside the injected PHP back to the Qiq host. -->
+        <lang.elementManipulator
+                forClass="io.github.jingu.idea_qiq_plugin.psi.QiqCodeHost"
+                implementationClass="io.github.jingu.idea_qiq_plugin.psi.QiqCodeHostManipulator"/>
+        <lang.elementManipulator
+                forClass="io.github.jingu.idea_qiq_plugin.psi.QiqPhpHost"
+                implementationClass="io.github.jingu.idea_qiq_plugin.psi.QiqPhpHostManipulator"/>
         <typedHandler implementation="io.github.jingu.idea_qiq_plugin.editor.QiqTypedHandler"/>
         <enterHandlerDelegate implementation="io.github.jingu.idea_qiq_plugin.editor.QiqEnterHandler"/>
     </extensions>

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/psi/QiqHostManipulatorTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/psi/QiqHostManipulatorTest.kt
@@ -1,0 +1,110 @@
+package io.github.jingu.idea_qiq_plugin.psi
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.PsiLanguageInjectionHost
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.testFramework.junit5.RunInEdt
+import com.intellij.testFramework.junit5.impl.TestApplicationExtension
+import com.intellij.testFramework.junit5.resources.ProjectExtension
+import io.github.jingu.idea_qiq_plugin.lang.QiqFileType
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.RegisterExtension
+
+@RunInEdt
+@ExtendWith(TestApplicationExtension::class)
+class QiqHostManipulatorTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val projectExtension = ProjectExtension()
+    }
+
+    @Test
+    fun updateTextRenamesIdentifierInEscapeHost(project: Project) {
+        assertUpdateTextRoundTrips(
+            project,
+            initial = "{{h \$article->title }}",
+            expectedHostText = " \$article->title ",
+            newText = " \$article->headline ",
+        )
+    }
+
+    @Test
+    fun updateTextWorksForEachEscapeDirective(project: Project) {
+        for (modifier in listOf("h", "a", "j", "u", "c")) {
+            assertUpdateTextRoundTrips(
+                project,
+                initial = "{{$modifier \$obj->old }}",
+                expectedHostText = " \$obj->old ",
+                newText = " \$obj->updated ",
+            )
+        }
+    }
+
+    @Test
+    fun updateTextWorksForRawEchoHost(project: Project) {
+        assertUpdateTextRoundTrips(
+            project,
+            initial = "{{= \$user->name }}",
+            expectedHostText = " \$user->name ",
+            newText = " \$user->displayName ",
+        )
+    }
+
+    @Test
+    fun updateTextWorksForCodeHost(project: Project) {
+        assertUpdateTextRoundTrips(
+            project,
+            initial = "{{ foreach (\$items as \$item): }}",
+            expectedHostText = " foreach (\$items as \$item): ",
+            newText = " foreach (\$rows as \$row): ",
+        )
+    }
+
+    @Test
+    fun updateTextWorksForInlinePhpHost(project: Project) {
+        assertUpdateTextRoundTrips(
+            project,
+            initial = "<?php \$user = new User(); ?>",
+            expectedHostText = " \$user = new User(); ",
+            newText = " \$person = new User(); ",
+        )
+    }
+
+    private fun assertUpdateTextRoundTrips(
+        project: Project,
+        initial: String,
+        expectedHostText: String,
+        newText: String,
+    ) {
+        val psiFile = readAction { createQiqFile(project, initial) }
+        val host = readAction {
+            PsiTreeUtil.collectElementsOfType(psiFile, PsiLanguageInjectionHost::class.java).single()
+        }
+        readAction {
+            assertEquals(expectedHostText, host.text, "Precondition: host text differs from expectation")
+        }
+
+        val updated = WriteAction.computeAndWait<PsiLanguageInjectionHost, RuntimeException> {
+            host.updateText(newText)
+        }
+
+        readAction {
+            assertEquals(newText, updated.text, "updateText did not reflect the new content")
+        }
+    }
+
+    private fun createQiqFile(project: Project, text: String): PsiFile =
+        PsiFileFactory.getInstance(project)
+            .createFileFromText("sample.qiq", QiqFileType, text)
+
+    private fun <T> readAction(block: () -> T): T =
+        ApplicationManager.getApplication().runReadAction<T>(block)
+}


### PR DESCRIPTION
## Summary

Both `QiqCodeHost` and `QiqPhpHost` implemented `PsiLanguageInjectionHost` with a no-op `updateText()` that returned the original host unchanged. As a result, IntelliJ refactorings (Rename, Move, etc.) found their target references inside the injected PHP but silently dropped the rewrite, leaving Qiq templates referring to renamed symbols.

This PR wires `updateText` through `ElementManipulators` and adds a manipulator for each host so refactorings now propagate into Qiq template text.

## Implementation

- **`QiqCodeHostManipulator`** wraps the new text in a parseable Qiq snippet derived from the host's element type (`ESCAPE_H_CONTENT` → `{{h NEW}}`, `RAW_CONTENT` → `{{= NEW}}`, `CODE_CONTENT` → `{{ NEW }}`, etc.), re-parses it, locates the matching host in the synthetic tree, and grafts its AST children into the original host node via `replaceAllChildrenToChildrenOf`. The host instance itself is preserved so any code holding a reference keeps working.
- **`QiqPhpHostManipulator`** does the same for inline `<?php ... ?>` blocks using `<?php NEW ?>` as the wrapping snippet.
- Both are registered via `<lang.elementManipulator>` in `plugin.xml`.
- `updateText()` in both hosts is reduced to `ElementManipulators.handleContentChange(this, text)`.

## What this enables

`updateText` is the rewrite step that every rename trigger eventually flows through. With this PR in place:

| Rename trigger | Before | After |
|---|---|---|
| Shift+F6 on a property in a PHP class file | Class declaration renamed; **Qiq template references silently skipped** | Class declaration renamed; **template references updated** |
| Find Usages → Rename All on a PHP property | Same as above | Same as above |
| Programmatic rename via PhpStorm refactoring API | Same as above | Same as above |

## Tests

`QiqHostManipulatorTest` (5 cases, all green):

- Rename inside `{{h $article->title }}` (also covers `a` / `j` / `u` / `c` directives in a loop)
- Rename inside `{{= $user->name }}` (raw echo)
- Rename inside `{{ foreach (...) }}` (statement code block)
- Rename inside `<?php $user = new User(); ?>` (inline PHP host)

Each test asserts that after `host.updateText(newText)`, `host.text == newText`.

## Manual verification (PhpStorm 2026.1, Qiq 1.1.1 project)

Renamed `Article::$htmlBody` → `body` (triggered from the PHP class file):

- Class declaration updated ✅
- Template reference inside `{{h $article->htmlBody }}` → `{{h $article->body }}` ✅
- Template reference inside `{{= $article->htmlBody }}` → `{{= $article->body }}` ✅

This confirms both injection paths (escape-routed via `QiqRuntimeFunctions*::h()` and raw `<?= ?>`) propagate correctly.

## Known limitation (follow-up)

Triggering rename **from inside an injected PHP fragment** (Shift+F6 with the cursor on `tags` in `{{h $article->tags }}` within a Qiq template) does not yet open the rename dialog. This is a separate problem from the one this PR solves:

- This PR handles the **rewrite step** — once a rename is in progress, the Qiq host text is updated correctly.
- The remaining gap is the **action-dispatch step** — getting Shift+F6 to recognize an injected PHP identifier inside a Qiq host as a renameable target. That requires extra plumbing (`RefactoringSupportProvider`, rename-handler delegation, etc.) and is out of scope here.

In the meantime, renaming from the PHP class side (Shift+F6 on the property declaration) or via Find Usages on the property propagates correctly to all Qiq template references.

A follow-up PR will address the template-side trigger.

## Test plan

- [x] `./gradlew test` — green, including new `QiqHostManipulatorTest`
- [x] `./gradlew buildPlugin` — produces a valid distribution
- [x] Real-project rename in PhpStorm (triggered from PHP class side) reaches both `{{h }}` and `{{= }}` template references

🤖 Generated with [Claude Code](https://claude.com/claude-code)