### PR TITLE
feat: enable Shift+F6 rename inside Qiq injected fragments

### DIFF
--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/navigation/QiqInjectedRenameHandler.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/navigation/QiqInjectedRenameHandler.kt
@@ -1,0 +1,112 @@
+package io.github.jingu.idea_qiq_plugin.navigation
+
+import com.intellij.lang.injection.InjectedLanguageManager
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiNameIdentifierOwner
+import com.intellij.psi.PsiNamedElement
+import com.intellij.psi.PsiReference
+import com.intellij.refactoring.rename.PsiElementRenameHandler
+import io.github.jingu.idea_qiq_plugin.lang.QiqTemplateLanguage
+
+/**
+ * Makes Shift+F6 work when the caret sits on a PHP identifier inside a Qiq
+ * injection host such as `{{h $article->title }}` or `<?php ... ?>`.
+ *
+ * The platform's default PsiElementRenameHandler reads
+ * CommonDataKeys.PSI_ELEMENT from the data context, which is set to the
+ * outer Qiq host (an unnamed wrapper) — that satisfies neither
+ * PsiNamedElement nor the renameability checks, so the action stays
+ * disabled for property references. Local variable rename happens to work
+ * via the default handler because variables expose themselves as
+ * PsiNamedElement reachable through other data keys, but property /
+ * method accesses do not.
+ *
+ * This handler descends into the injected fragment via
+ * InjectedLanguageManager, then walks parents and asks PHP's own
+ * references to resolve themselves. The first reference whose resolution
+ * is a PsiNameIdentifierOwner becomes the rename target. PHP's type
+ * inference already has the injected context wired by our
+ * MultiHostInjector, so resolution covers variables, properties, methods
+ * and class references uniformly.
+ *
+ * Scope: the handler only fires when the top-level (host) file's language
+ * is Qiq, so it does not compete with PHP's own handlers in plain `.php`
+ * files. The platform pre-narrows PSI_FILE in the data context to the
+ * most specific file at the caret (sometimes the injected PHP file,
+ * sometimes the outer Qiq file); the host check normalizes both cases.
+ */
+class QiqInjectedRenameHandler : PsiElementRenameHandler() {
+
+    override fun isAvailableOnDataContext(dataContext: DataContext): Boolean =
+        findInjectedTarget(dataContext) != null
+
+    override fun isRenaming(dataContext: DataContext): Boolean =
+        isAvailableOnDataContext(dataContext)
+
+    override fun invoke(project: Project, editor: Editor?, file: PsiFile?, dataContext: DataContext) {
+        val target = findInjectedTarget(dataContext) ?: return
+        invoke(project, arrayOf(target), dataContext)
+    }
+
+    private fun findInjectedTarget(ctx: DataContext): PsiElement? {
+        val editor = CommonDataKeys.EDITOR.getData(ctx) ?: return null
+        val file = CommonDataKeys.PSI_FILE.getData(ctx) ?: return null
+        val offset = editor.caretModel.offset
+
+        val ilm = InjectedLanguageManager.getInstance(file.project)
+        val hostFile = ilm.getTopLevelFile(file)
+        if (hostFile.language !is QiqTemplateLanguage) return null
+
+        val injectedElement = if (file !== hostFile) {
+            file.findElementAt(offset)
+        } else {
+            ilm.findInjectedElementAt(file, offset)
+        } ?: return null
+
+        return resolveRenameTarget(injectedElement)
+    }
+
+    private fun resolveRenameTarget(start: PsiElement): PsiNamedElement? {
+        var current: PsiElement? = start
+        var depth = 0
+        while (current != null && current !is PsiFile && depth <= MAX_WALK_DEPTH) {
+            resolveAcrossReferences(current)?.let { return it }
+            if (current is PsiNameIdentifierOwner &&
+                current.nameIdentifier != null &&
+                (current as PsiNamedElement).name != null
+            ) {
+                return current
+            }
+            current = current.parent
+            depth++
+        }
+        return null
+    }
+
+    private fun resolveAcrossReferences(element: PsiElement): PsiNamedElement? {
+        if (element is PsiReference) {
+            (element as PsiReference).resolve()?.let { resolved ->
+                if (resolved is PsiNamedElement && resolved != element && resolved.name != null) {
+                    return resolved
+                }
+            }
+        }
+        for (ref in element.references) {
+            val resolved = ref.resolve()
+            if (resolved is PsiNamedElement && resolved != element && resolved.name != null) {
+                return resolved
+            }
+        }
+        return null
+    }
+
+    private companion object {
+        // Safety cap so a degenerate PSI cannot trap us in a tight loop.
+        const val MAX_WALK_DEPTH = 12
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -62,6 +62,12 @@
         <lang.elementManipulator
                 forClass="io.github.jingu.idea_qiq_plugin.psi.QiqPhpHost"
                 implementationClass="io.github.jingu.idea_qiq_plugin.psi.QiqPhpHostManipulator"/>
+
+        <!-- Forward Shift+F6 inside a Qiq injection host to the injected
+             PHP rename pipeline (the default handler only sees the outer
+             unnamed Qiq host and disables the action). -->
+        <renameHandler
+                implementation="io.github.jingu.idea_qiq_plugin.navigation.QiqInjectedRenameHandler"/>
         <typedHandler implementation="io.github.jingu.idea_qiq_plugin.editor.QiqTypedHandler"/>
         <enterHandlerDelegate implementation="io.github.jingu.idea_qiq_plugin.editor.QiqEnterHandler"/>
     </extensions>


### PR DESCRIPTION
## Summary

Pressing **Shift+F6 on a PHP identifier inside a Qiq template** — for example the property name in `{{h \$article->title }}` or any identifier inside an inline `<?php ... ?>` host — did not open the rename dialog. Local variable rename happened to work, but property and method accesses silently failed.

Closes the follow-up tracked in PR #13.

## Root cause

The platform's default `PsiElementRenameHandler` reads `CommonDataKeys.PSI_ELEMENT` from the data context, which resolves to the outer Qiq host (an unnamed wrapper). The host satisfies neither `PsiNamedElement` nor `canRename`, so the action is disabled. The previous PR's `ElementManipulator` work was correct for the rewrite step, but the dispatch step (recognizing the caret position as renameable) was missing — `<lang.elementManipulator>` only matters once a rename pipeline has already chosen a target.

Confirmed empirically by adding a temporary `Logger.warn` to a draft handler and reading `idea.log`: the leaf returned by `file.findElementAt(offset)` inside an injected fragment was always a PHP leaf with no `QiqCodeHost` / `QiqPhpHost` ancestor, because `PSI_FILE` in the data context was the injected PHP file itself.

## Implementation

Single new class `QiqInjectedRenameHandler`, registered via `<renameHandler>`:

- **Scope check** uses `InjectedLanguageManager.getTopLevelFile(file).language is QiqTemplateLanguage`. This normalizes both cases the platform may give us (PSI_FILE = injected PHP file vs. outer Qiq file) and prevents competing with PHP's own handlers in plain `.php` files.
- **Target lookup** descends into the injected fragment via `InjectedLanguageManager.findInjectedElementAt`, then walks parents. At each step it asks PHP's own references to resolve themselves (`PsiReference.resolve()` directly when the element implements it, and via `element.references` otherwise), falling back to the element itself when it is a `PsiNameIdentifierOwner`. This handles variables, properties, methods and class references uniformly through PHP's resolution, which already has the injected context wired by our `MultiHostInjector`.
- **Dispatch** hands the resolved target off to `PsiElementRenameHandler`'s standard pipeline, which then uses the host's `ElementManipulator` (added in PR #13) to rewrite the Qiq host text.

## Bidirectional rename, end-to-end

With this PR merged together with #13:

| Trigger | Before #13 | After #13 | After this PR |
|---|---|---|---|
| Shift+F6 on PHP class field (in `.php` file) | declaration renamed, **templates not updated** | declaration and template references both renamed | (unchanged — already worked) |
| Shift+F6 on local `$variable` inside `{{h \$foo->bar }}` | dialog opens but no update in template | dialog opens, all template refs updated | dialog opens, all template refs updated |
| **Shift+F6 on property name inside `{{h \$foo->bar }}`** | **no dialog** | **no dialog** | **dialog opens, all refs updated** |
| Shift+F6 on identifier inside `<?php ... ?>` host | no dialog (for properties) | no dialog (for properties) | dialog opens, all refs updated |

## Tests

Action-layer tests for `RenameHandler` would require a `LightJavaCodeInsightFixtureTestCase` with PHP plugin fixtures and a full injected setup, which is significantly heavier than the rest of this project's test surface. Verified manually in PhpStorm 2026.1 instead:

- ✅ Property rename triggered from inside `{{h \$article->title }}` opens the dialog, renames the class field, and propagates back to all template references.
- ✅ Local variable rename inside templates continues to work (no regression).
- ✅ Rename inside `<?php ... ?>` blocks inside templates works for properties.
- ✅ Rename in plain `.php` files (outside any Qiq template) is unaffected — the scope check excludes them so this handler does not compete with PHP's own.

## Risks

- **Handler precedence:** the handler returns `true` from `isAvailableOnDataContext` only when the caret resolves to a `PsiNamedElement` reachable from a Qiq host. In Qiq files where the default handler would otherwise also fire (e.g. on `$article` itself, where the default works), the registry will list both. The current observation is that variable rename works as before with no chooser, but if a chooser surfaces in some corner case, a follow-up can return `false` when the resolved target is something PHP's handler would already handle directly.

## Test plan

- [x] `./gradlew test` — existing tests green
- [x] `./gradlew buildPlugin` — produces a valid distribution
- [x] Manual: Shift+F6 on a property reference inside `{{h ... }}` opens the rename dialog and propagates correctly to both the PHP class and all template references

🤖 Generated with [Claude Code](https://claude.com/claude-code)