### PR TITLE
chore: prepare 0.6.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,18 @@ Qiq Templates Support is an IntelliJ-based plugin that brings syntax highlightin
 
 - **Syntax highlighting** for Qiq control structures, escape modifiers (`{{= }}`, `{{h }}`, etc.), and HTML blocks.
 - **PHP language injection** inside Qiq tokens and inline `<?php ?>` islands so that autocompletion, inspections, and formatting work as expected.
+- **Type-aware escape directives**: `{{h }}`, `{{a }}`, `{{j }}`, `{{u }}`, `{{c }}` are routed through typed runtime stubs so PhpStorm flags wrong argument types (`{{h $array }}`, `{{h $objectWithoutToString }}`, etc.).
+- **Composer-aware stub selection**: the strict (Qiq 1.x) or relaxed (Qiq 2.x / 3.x) escape signature is chosen automatically from `composer.lock`.
+- **Cross-template rename refactoring**: renaming a PHP property, method, or local variable propagates into every Qiq template that references it. Triggering Shift+F6 from inside a Qiq template (`{{h $article->title }}`) also works.
 - **Cross-template navigation**: Cmd/Ctrl+click (Go to Declaration) on `setLayout()`, `render()`, `include()`, or custom helpers to open the referenced template file.
 - **Enter/typing handlers** that auto-complete Qiq block closers and keep indentation consistent.
 - **Template discovery**: resolves relative paths by walking up from the current file, project roots, and PHP server document roots.
+
+## Settings
+
+Open **Settings (Preferences) → Languages & Frameworks → Qiq Templates** for project-level options:
+
+- **Inject `declare(strict_types=1)` into Qiq templates** *(off by default)* — when enabled, scalar literal misuses such as `{{h true }}`, `{{h 123 }}`, or `{{h null }}` surface as PhpStorm type warnings. Useful when your project renders templates under PHP strict types; off by default to match Qiq's runtime, which performs implicit scalar→string casts.
 
 ## Installation
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ intellijPlatform {
     pluginConfiguration {
         name.set("Qiq Templates Support")
         id.set("io.github.jingu.idea-qiq-plugin")
-        version.set("0.5.0")
+        version.set("0.6.0")
         ideaVersion {
             sinceBuild.set("241")
             untilBuild.set("261.*")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,7 +58,15 @@ intellijPlatform {
             sinceBuild.set("241")
             untilBuild.set("261.*")
         }
-        description.set("Syntax highlighting and simple navigation for Qiq templates")
+        description.set(
+            "Qiq template support for PhpStorm: HTML-aware syntax highlighting, full PHP " +
+                "injection inside Qiq tags and inline <?php ?> blocks, cross-template rename " +
+                "refactoring (Shift+F6 works both from PHP and from inside templates), and " +
+                "type-checked escape directives — wrong types passed to {{h }}, {{a }}, " +
+                "{{j }}, {{u }}, {{c }} are flagged at edit time by PhpStorm's own Type " +
+                "Compatibility inspection, with strict / relaxed signatures auto-selected " +
+                "from composer.lock."
+        )
         vendor {
             name.set("Yoshitaka Jingu")
             url.set("https://github.com/jingu/idea-php-qiq-plugin")

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -40,6 +40,8 @@
         <lang.commenter
                 language="Qiq"
                 implementationClass="io.github.jingu.idea_qiq_plugin.editor.QiqCommenter"/>
+        <typedHandler implementation="io.github.jingu.idea_qiq_plugin.editor.QiqTypedHandler"/>
+        <enterHandlerDelegate implementation="io.github.jingu.idea_qiq_plugin.editor.QiqEnterHandler"/>
 
         <!-- Color Settings Page -->
         <colorSettingsPage implementation="io.github.jingu.idea_qiq_plugin.ui.QiqColorSettingsPage"/>
@@ -76,8 +78,6 @@
                 id="settings.qiq"
                 key="settings.qiq.display.name"
                 bundle="messages.QiqBundle"/>
-        <typedHandler implementation="io.github.jingu.idea_qiq_plugin.editor.QiqTypedHandler"/>
-        <enterHandlerDelegate implementation="io.github.jingu.idea_qiq_plugin.editor.QiqEnterHandler"/>
     </extensions>
 
     <!-- PHP ライブラリスタブの登録（任意） -->
@@ -93,9 +93,21 @@
     </actions>
     <change-notes><![CDATA[
 <ul>
-  <li><b>PhpStorm 2026.1 Support</b>
+  <li><b>Type-aware escape directives</b>
     <ul>
-      <li>Extended compatibility to PhpStorm 2026.1 (build 261).</li>
+      <li><code>{{h }}</code>, <code>{{a }}</code>, <code>{{j }}</code>, <code>{{u }}</code>, <code>{{c }}</code> are routed through typed runtime stubs so PhpStorm flags wrong argument types (arrays, objects without <code>__toString</code>, etc.).</li>
+      <li>The strict (Qiq 1.x) or relaxed (Qiq 2.x / 3.x) escape signature is selected automatically from <code>composer.lock</code>.</li>
+    </ul>
+  </li>
+  <li><b>Cross-template rename refactoring</b>
+    <ul>
+      <li>Renaming a PHP property, method, or local variable now propagates into Qiq template references.</li>
+      <li>Shift+F6 triggered from inside a Qiq template (e.g. on <code>title</code> in <code>{{h $article-&gt;title }}</code>) opens the rename dialog and updates both the PHP declaration and every template usage.</li>
+    </ul>
+  </li>
+  <li><b>Strict Types setting</b>
+    <ul>
+      <li>New project setting under <i>Settings &gt; Languages &amp; Frameworks &gt; Qiq Templates</i> that injects <code>declare(strict_types=1)</code> into Qiq templates so scalar literal misuses such as <code>{{h true }}</code> or <code>{{h 123 }}</code> surface as type warnings. Off by default.</li>
     </ul>
   </li>
 </ul>


### PR DESCRIPTION
## Summary

Release prep collecting the user-visible work from PR #12, #13, #14, and #15:

| PR | Feature theme |
|---|---|
| [#12](https://github.com/jingu/idea-php-qiq-plugin/pull/12) | Route escape directives through typed runtime stubs (composer-aware) |
| [#13](https://github.com/jingu/idea-php-qiq-plugin/pull/13) | Propagate refactorings into Qiq host text |
| [#14](https://github.com/jingu/idea-php-qiq-plugin/pull/14) | Enable Shift+F6 rename from inside Qiq injected fragments |
| [#15](https://github.com/jingu/idea-php-qiq-plugin/pull/15) | Add Strict Types project setting |

## Changes

- **README**: new Features bullets for type-aware escape directives, composer-aware stub selection, and cross-template rename refactoring; new Settings section documenting the Strict Types switch.
- **`plugin.xml` `<change-notes>`**: refreshed for 0.6.0 covering the three feature themes above (escape directive typing, rename propagation + template-side trigger, Strict Types setting).
- **`plugin.xml` extension order**: `<typedHandler>` and `<enterHandlerDelegate>` moved next to the other editor extensions (after `<lang.commenter>`) instead of trailing after `<projectConfigurable>`; they had drifted as new registrations were appended at the bottom.
- **`build.gradle.kts` version**: 0.5.0 → 0.6.0.
- **`build.gradle.kts` description**: replaced "Syntax highlighting and simple navigation for Qiq templates" with a one-paragraph blurb that covers what the plugin actually does after PR #12-#15. Research across Twig, Laravel Idea/Blade, Latte, Smarty, and Volt confirmed no other mainstream PHP template plugin currently surfaces type mismatches inside output / escape tags at edit time, so the wording mentions this without overclaiming.

## Test plan

- [x] `./gradlew test` — all green
- [x] `./gradlew buildPlugin` — produces `build/distributions/QiqLanguagePlugin.zip`
- [ ] Manual: verify the change-notes and description render correctly on the JetBrains Marketplace once published

🤖 Generated with [Claude Code](https://claude.com/claude-code)