### PR TITLE
chore: prepare 0.7.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Qiq Templates Support is an IntelliJ-based plugin that brings syntax highlightin
 - **Composer-aware stub selection**: the strict (Qiq 1.x) or relaxed (Qiq 2.x / 3.x) escape signature is chosen automatically from `composer.lock`.
 - **Cross-template rename refactoring**: renaming a PHP property, method, or local variable propagates into every Qiq template that references it. Triggering Shift+F6 from inside a Qiq template (`{{h $article->title }}`) also works.
 - **Cross-template navigation**: Cmd/Ctrl+click (Go to Declaration) on `setLayout()`, `render()`, `include()`, or custom helpers to open the referenced template file.
-- **Helper Go to Declaration**: Cmd/Ctrl+click on a helper call (`{{ helperName(...) }}` / `{{ $this->helperName(...) }}`) jumps to its PHP declaration. Qiq 2.x/3.x helpers (public methods on a `Qiq\Helpers` subclass) are discovered automatically; Qiq 1.x `HelperLocator::set()` helpers resolve once you point the plugin at your registration file in settings. Resolvable helper calls also stop triggering the "undefined function" warning.
+- **Helper Go to Declaration**: Cmd/Ctrl+click on a helper call (`{{ helperName(...) }}` / `{{ $this->helperName(...) }}`) jumps to its PHP declaration. Qiq 2.x/3.x helpers (public methods on a `Qiq\Helpers` subclass) are discovered automatically; Qiq 1.x `HelperLocator::set()` helpers resolve once you point the plugin at your registration file in settings. Resolvable helper calls also stop triggering the "undefined function/method" warning.
 - **Enter/typing handlers** that auto-complete Qiq block closers and keep indentation consistent.
 - **Template discovery**: resolves relative paths by walking up from the current file, project roots, and PHP server document roots.
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Qiq Templates Support is an IntelliJ-based plugin that brings syntax highlightin
 - **Composer-aware stub selection**: the strict (Qiq 1.x) or relaxed (Qiq 2.x / 3.x) escape signature is chosen automatically from `composer.lock`.
 - **Cross-template rename refactoring**: renaming a PHP property, method, or local variable propagates into every Qiq template that references it. Triggering Shift+F6 from inside a Qiq template (`{{h $article->title }}`) also works.
 - **Cross-template navigation**: Cmd/Ctrl+click (Go to Declaration) on `setLayout()`, `render()`, `include()`, or custom helpers to open the referenced template file.
+- **Helper Go to Declaration**: Cmd/Ctrl+click on a helper call (`{{ helperName(...) }}` / `{{ $this->helperName(...) }}`) jumps to its PHP declaration. Qiq 2.x/3.x helpers (public methods on a `Qiq\Helpers` subclass) are discovered automatically; Qiq 1.x `HelperLocator::set()` helpers resolve once you point the plugin at your registration file in settings. Resolvable helper calls also stop triggering the "undefined function" warning.
 - **Enter/typing handlers** that auto-complete Qiq block closers and keep indentation consistent.
 - **Template discovery**: resolves relative paths by walking up from the current file, project roots, and PHP server document roots.
 
@@ -21,6 +22,7 @@ Qiq Templates Support is an IntelliJ-based plugin that brings syntax highlightin
 Open **Settings (Preferences) → Languages & Frameworks → Qiq Templates** for project-level options:
 
 - **Inject `declare(strict_types=1)` into Qiq templates** *(off by default)* — when enabled, scalar literal misuses such as `{{h true }}`, `{{h 123 }}`, or `{{h null }}` surface as PhpStorm type warnings. Useful when your project renders templates under PHP strict types; off by default to match Qiq's runtime, which performs implicit scalar→string casts.
+- **Helper Locator bootstrap files** — for Qiq 1.x projects, list the PHP file(s) that register helpers via `$locator->set('name', ...)`. The plugin scans them to resolve helper calls for Go to Declaration. Not needed for Qiq 2.x/3.x, whose `Qiq\Helpers` subclasses are discovered automatically.
 
 ## Installation
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ intellijPlatform {
     pluginConfiguration {
         name.set("Qiq Templates Support")
         id.set("io.github.jingu.idea-qiq-plugin")
-        version.set("0.6.0")
+        version.set("0.7.0")
         ideaVersion {
             sinceBuild.set("241")
             untilBuild.set("261.*")

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -117,10 +117,10 @@
     <ul>
       <li>Cmd/Ctrl+click on a helper call (<code>{{ helperName(...) }}</code> or <code>{{ $this-&gt;helperName(...) }}</code>) now jumps to the helper's PHP declaration.</li>
       <li><b>Qiq 2.x / 3.x</b>: public methods on a <code>Qiq\Helpers</code> subclass (the official custom-helper style) are discovered automatically &mdash; no configuration needed.</li>
-      <li><b>Qiq 1.x</b>: helpers registered via <code>HelperLocator::set('name', ...)</code> resolve once you point the plugin at your registration file under <i>Settings &gt; Languages &amp; Frameworks &gt; Qiq Templates &gt; Helper Locator bootstrap files</i>.</li>
+      <li><b>Qiq 1.x</b>: helpers registered via <code>HelperLocator::set('name', ...)</code> resolve once you point the plugin at your registration file(s) under <i>Settings &gt; Languages &amp; Frameworks &gt; Qiq Templates &gt; Helper Locator bootstrap files</i>.</li>
     </ul>
   </li>
-  <li><b>Fewer false &ldquo;undefined function&rdquo; warnings</b>
+  <li><b>Fewer false &ldquo;undefined function/method&rdquo; warnings</b>
     <ul>
       <li>Resolvable helper calls inside Qiq templates no longer trigger PhpStorm's undefined function/method inspection.</li>
     </ul>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -113,21 +113,21 @@
     </actions>
     <change-notes><![CDATA[
 <ul>
-  <li><b>Type-aware escape directives</b>
+  <li><b>Go to Declaration for Qiq helpers</b>
     <ul>
-      <li><code>{{h }}</code>, <code>{{a }}</code>, <code>{{j }}</code>, <code>{{u }}</code>, <code>{{c }}</code> are routed through typed runtime stubs so PhpStorm flags wrong argument types (arrays, objects without <code>__toString</code>, etc.).</li>
-      <li>The strict (Qiq 1.x) or relaxed (Qiq 2.x / 3.x) escape signature is selected automatically from <code>composer.lock</code>.</li>
+      <li>Cmd/Ctrl+click on a helper call (<code>{{ helperName(...) }}</code> or <code>{{ $this-&gt;helperName(...) }}</code>) now jumps to the helper's PHP declaration.</li>
+      <li><b>Qiq 2.x / 3.x</b>: public methods on a <code>Qiq\Helpers</code> subclass (the official custom-helper style) are discovered automatically &mdash; no configuration needed.</li>
+      <li><b>Qiq 1.x</b>: helpers registered via <code>HelperLocator::set('name', ...)</code> resolve once you point the plugin at your registration file under <i>Settings &gt; Languages &amp; Frameworks &gt; Qiq Templates &gt; Helper Locator bootstrap files</i>.</li>
     </ul>
   </li>
-  <li><b>Cross-template rename refactoring</b>
+  <li><b>Fewer false &ldquo;undefined function&rdquo; warnings</b>
     <ul>
-      <li>Renaming a PHP property, method, or local variable now propagates into Qiq template references.</li>
-      <li>Shift+F6 triggered from inside a Qiq template (e.g. on <code>title</code> in <code>{{h $article-&gt;title }}</code>) opens the rename dialog and updates both the PHP declaration and every template usage.</li>
+      <li>Resolvable helper calls inside Qiq templates no longer trigger PhpStorm's undefined function/method inspection.</li>
     </ul>
   </li>
-  <li><b>Strict Types setting</b>
+  <li><b>Fix: raw-echo helper names</b>
     <ul>
-      <li>New project setting under <i>Settings &gt; Languages &amp; Frameworks &gt; Qiq Templates</i> that injects <code>declare(strict_types=1)</code> into Qiq templates so scalar literal misuses such as <code>{{h true }}</code> or <code>{{h 123 }}</code> surface as type warnings. Off by default.</li>
+      <li><code>{{= asset(...) }}</code> and other <code>{{= }}</code> calls whose names start with <code>h</code>/<code>a</code>/<code>j</code>/<code>u</code>/<code>c</code> (e.g. <code>asset</code>, <code>currentUrl</code>, <code>upper</code>) are no longer mis-parsed by stripping the leading letter as an escape modifier.</li>
     </ul>
   </li>
 </ul>


### PR DESCRIPTION
## Summary
Release preparation for **0.7.0**. The only feature-level change since the `0.6.0` tag is the Qiq helper Go to Declaration work (PR #17), already merged to `develop`.

- Bump plugin version `0.6.0` → `0.7.0` (`build.gradle.kts`).
- Refresh `<change-notes>` in `plugin.xml` to describe the 0.7.0 highlights.
- Update README Features / Settings for helper navigation and the Helper Locator bootstrap-files setting.

## 0.7.0 highlights
- **Go to Declaration for Qiq helpers**: Cmd/Ctrl+click on `{{ helperName(...) }}` / `{{ $this->helperName(...) }}`.
  - Qiq 2.x/3.x: `Qiq\Helpers` subclass methods discovered automatically (no config).
  - Qiq 1.x: `HelperLocator::set('name', ...)` helpers resolved via user-configured bootstrap files.
- **Undefined function/method warning suppression** for resolvable helper calls in Qiq templates.
- **Fix**: `{{= asset(...) }}` (and other `{{= }}` calls starting with `h`/`a`/`j`/`u`/`c`) no longer have their leading letter stripped as an escape modifier.

## Test plan
- [x] `./gradlew clean test` — all suites green
- [x] `./gradlew buildPlugin` — `QiqLanguagePlugin-0.7.0.jar`, `<version>0.7.0</version>` and updated change-notes verified in the packaged plugin.xml
- [ ] After merge: tag `0.7.0` on the merge commit (mirrors the `0.6.0` flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)