### PR TITLE
feat: complete template paths in setLayout/render/extends/include

### DIFF
--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/completion/QiqTemplatePathCompletionContributor.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/completion/QiqTemplatePathCompletionContributor.kt
@@ -5,6 +5,7 @@ import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.CompletionProvider
 import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.codeInsight.completion.PlainPrefixMatcher
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.lang.injection.InjectedLanguageManager
 import com.intellij.openapi.progress.ProgressManager
@@ -58,23 +59,42 @@ class QiqTemplatePathCompletionContributor : CompletionContributor() {
                 .virtualFile ?: return
 
             val settings = QiqSettingsService.getInstance(project)
-            val roots = settings.resolveTemplateRoots(contextFile)
-            if (roots.isEmpty()) return
             val extensions = settings.state.candidateExtensions
 
             // Replace the already-typed in-quote text, so `layout/ba` is
             // matched/replaced rather than matching against the whole literal.
             val typedPrefix = inQuotePrefix(stringLiteral, parameters.offset) ?: return
-            val pathResult = result.withPrefixMatcher(typedPrefix)
 
-            val paths = LinkedHashSet<String>()
-            for (root in roots) {
-                collectTemplatePaths(root, root, extensions, paths)
+            // Substring matching (PlainPrefixMatcher in contains mode, not the
+            // default camel-hump matcher): the leading `/` is optional in Qiq, so
+            // `partial/ad` must surface `/partial/ad/adtag`, and any path that
+            // contains the typed fragment is offered. True prefix hits still rank
+            // first via the matcher's isStartMatch.
+            val pathResult = result.withPrefixMatcher(PlainPrefixMatcher(typedPrefix, false))
+
+            val seen = HashSet<String>()
+            fun offer(path: String) {
+                if (seen.add(path)) {
+                    pathResult.addElement(LookupElementBuilder.create(path).withTypeText("Qiq template", true))
+                }
             }
-            for (path in paths) {
-                pathResult.addElement(
-                    LookupElementBuilder.create(path).withTypeText("Qiq template", true),
-                )
+
+            // Relative paths, resolved against the directory the current template
+            // lives in (a bare `partial/...` as written without a leading slash).
+            for (root in settings.resolveTemplateRoots(contextFile)) {
+                val rel = LinkedHashSet<String>()
+                collectTemplatePaths(root, root, extensions, rel)
+                rel.forEach(::offer)
+            }
+
+            // Root-absolute paths from the template base (`/layout/base`) — the
+            // form layouts and shared partials are usually referenced by. Offered
+            // with the leading `/` so the slash is part of the completed text;
+            // PlainPrefixMatcher keeps `/l` matching only `/layout/...`.
+            settings.resolveTemplateBase(contextFile)?.let { base ->
+                val abs = LinkedHashSet<String>()
+                collectTemplatePaths(base, base, extensions, abs)
+                abs.forEach { offer("/$it") }
             }
         }
 

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/completion/QiqTemplatePathCompletionContributor.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/completion/QiqTemplatePathCompletionContributor.kt
@@ -1,0 +1,138 @@
+package io.github.jingu.idea_qiq_plugin.completion
+
+import com.intellij.codeInsight.completion.CompletionContributor
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionProvider
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.lang.injection.InjectedLanguageManager
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.vfs.VfsUtilCore
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.util.ProcessingContext
+import com.jetbrains.php.lang.psi.elements.FunctionReference
+import com.jetbrains.php.lang.psi.elements.ParameterList
+import com.jetbrains.php.lang.psi.elements.StringLiteralExpression
+import io.github.jingu.idea_qiq_plugin.lang.QiqInjectionSupport
+import io.github.jingu.idea_qiq_plugin.settings.QiqSettingsService
+
+/**
+ * Completes template paths in the first string argument of Qiq's
+ * template-referencing calls — `setLayout('...')`, `render('...')`,
+ * `extends('...')`, `include('...')` — inside Qiq templates.
+ *
+ * Candidates are the template files found under
+ * [QiqSettingsService.resolveTemplateRoots] for the current file, listed as
+ * root-relative paths with the Qiq extension stripped (so `layout/base.qiq.php`
+ * is offered as `layout/base`). Pairs with the existing Go to Declaration on
+ * the same arguments.
+ */
+class QiqTemplatePathCompletionContributor : CompletionContributor() {
+
+    init {
+        extend(
+            CompletionType.BASIC,
+            PlatformPatterns.psiElement(),
+            TemplatePathCompletionProvider(),
+        )
+    }
+
+    private class TemplatePathCompletionProvider : CompletionProvider<CompletionParameters>() {
+        override fun addCompletions(
+            parameters: CompletionParameters,
+            context: ProcessingContext,
+            result: CompletionResultSet,
+        ) {
+            val position = parameters.position
+            if (!QiqInjectionSupport.isInQiqFile(position)) return
+
+            val stringLiteral = PsiTreeUtil.getParentOfType(position, StringLiteralExpression::class.java) ?: return
+            if (!isFirstArgOfTemplateCall(stringLiteral)) return
+
+            val project = position.project
+            val ilm = InjectedLanguageManager.getInstance(project)
+            val contextFile = (ilm.getTopLevelFile(parameters.originalFile) ?: parameters.originalFile)
+                .virtualFile ?: return
+
+            val settings = QiqSettingsService.getInstance(project)
+            val roots = settings.resolveTemplateRoots(contextFile)
+            if (roots.isEmpty()) return
+            val extensions = settings.state.candidateExtensions
+
+            // Replace the already-typed in-quote text, so `layout/ba` is
+            // matched/replaced rather than matching against the whole literal.
+            val typedPrefix = inQuotePrefix(stringLiteral, parameters.offset) ?: return
+            val pathResult = result.withPrefixMatcher(typedPrefix)
+
+            val paths = LinkedHashSet<String>()
+            for (root in roots) {
+                collectTemplatePaths(root, root, extensions, paths)
+            }
+            for (path in paths) {
+                pathResult.addElement(
+                    LookupElementBuilder.create(path).withTypeText("Qiq template", true),
+                )
+            }
+        }
+
+        private fun isFirstArgOfTemplateCall(stringLiteral: StringLiteralExpression): Boolean {
+            val parameterList = stringLiteral.parent as? ParameterList ?: return false
+            val call = parameterList.parent as? FunctionReference ?: return false
+            if (call.name !in TEMPLATE_FUNCTIONS) return false
+            return parameterList.parameters.firstOrNull() === stringLiteral
+        }
+
+        /** The in-quote text before the caret, excluding the surrounding quote. */
+        private fun inQuotePrefix(stringLiteral: StringLiteralExpression, caretOffset: Int): String? {
+            val caretInLiteral = caretOffset - stringLiteral.textRange.startOffset
+            val text = stringLiteral.text
+            // index 0 is the opening quote; require the caret to sit past it.
+            if (caretInLiteral < 1 || caretInLiteral > text.length) return null
+            return text.substring(1, caretInLiteral)
+        }
+
+        private fun collectTemplatePaths(
+            dir: VirtualFile,
+            root: VirtualFile,
+            extensions: List<String>,
+            out: MutableSet<String>,
+        ) {
+            if (out.size >= MAX_CANDIDATES) return
+            for (child in dir.children) {
+                ProgressManager.checkCanceled()
+                if (out.size >= MAX_CANDIDATES) return
+                if (child.isDirectory) {
+                    collectTemplatePaths(child, root, extensions, out)
+                } else {
+                    val relative = VfsUtilCore.getRelativePath(child, root) ?: continue
+                    stripTemplateExtension(relative, extensions)?.let(out::add)
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val MAX_CANDIDATES = 2000
+        private val TEMPLATE_FUNCTIONS = setOf("setLayout", "render", "extends", "include")
+
+        /**
+         * Strip the first matching Qiq [extensions] entry from [relativePath],
+         * or return null when the file is not a template. [extensions] is
+         * checked in order, so list longer suffixes first (e.g. `.qiq.php`
+         * before `.php`) to avoid leaving a dangling `.qiq`.
+         *
+         * Pure helper, unit-tested independently of the VFS walk.
+         */
+        fun stripTemplateExtension(relativePath: String, extensions: List<String>): String? {
+            for (ext in extensions) {
+                if (relativePath.endsWith(ext, ignoreCase = true)) {
+                    return relativePath.dropLast(ext.length)
+                }
+            }
+            return null
+        }
+    }
+}

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inspection/QiqTemplatePathInspection.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inspection/QiqTemplatePathInspection.kt
@@ -1,0 +1,66 @@
+package io.github.jingu.idea_qiq_plugin.inspection
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.lang.injection.InjectedLanguageManager
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElementVisitor
+import com.jetbrains.php.lang.psi.elements.FunctionReference
+import com.jetbrains.php.lang.psi.elements.MethodReference
+import com.jetbrains.php.lang.psi.elements.StringLiteralExpression
+import com.jetbrains.php.lang.psi.elements.Variable
+import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor
+import io.github.jingu.idea_qiq_plugin.lang.QiqInjectionSupport
+import io.github.jingu.idea_qiq_plugin.ui.QiqBundle
+import io.github.jingu.idea_qiq_plugin.util.QiqUtil
+
+/**
+ * Warns when a Qiq template-referencing call points at a template that does not
+ * exist — the editor-time counterpart to the Go to Declaration on the same
+ * argument.
+ *
+ * Only the calls that take a template path are inspected — `setLayout`,
+ * `render`, `extends`, `include` — and only their first argument when it is a
+ * plain string literal (interpolated or concatenated paths are left alone).
+ * Existence is decided by [QiqUtil.findTemplateByPath], the exact resolver
+ * Go to Declaration uses, so a path is flagged precisely when Cmd/Ctrl+click
+ * would fail to navigate. A method call is treated as a template call only when
+ * its receiver is `$this`, to avoid flagging an unrelated `$other->render(...)`.
+ */
+class QiqTemplatePathInspection : LocalInspectionTool() {
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
+        object : PhpElementVisitor() {
+            override fun visitPhpFunctionCall(reference: FunctionReference) = inspectCall(reference, holder)
+
+            override fun visitPhpMethodReference(reference: MethodReference) = inspectCall(reference, holder)
+        }
+
+    private fun inspectCall(call: FunctionReference, holder: ProblemsHolder) {
+        if (!QiqInjectionSupport.isInQiqFile(call)) return
+
+        val name = call.name?.takeIf { it.isNotEmpty() } ?: return
+        if (name !in TEMPLATE_FUNCTIONS) return
+        // `$foo->render(...)` is some other object's method; only `$this->...`
+        // (and bare calls) reference a Qiq template.
+        if (call is MethodReference && (call.classReference as? Variable)?.name != "this") return
+
+        val arg = call.parameterList?.parameters?.firstOrNull() as? StringLiteralExpression ?: return
+        val path = arg.contents
+        // Skip blanks and anything dynamic (interpolation / unusual spacing) we
+        // cannot resolve statically.
+        if (path.isBlank() || path.contains(' ') || path.contains('$')) return
+
+        val contextFile = InjectedLanguageManager.getInstance(call.project).getTopLevelFile(call)?.virtualFile
+            ?: call.containingFile?.virtualFile
+            ?: return
+        if (QiqUtil.findTemplateByPath(call.project, path, contextFile) != null) return
+
+        val range = TextRange(1, arg.textLength - 1).takeIf { it.startOffset < it.endOffset } ?: return
+        holder.registerProblem(arg, range, QiqBundle.message("inspection.template.path.missing", path))
+    }
+
+    private companion object {
+        private val TEMPLATE_FUNCTIONS = setOf("setLayout", "render", "extends", "include")
+    }
+}

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inspection/QiqTemplatePathInspection.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inspection/QiqTemplatePathInspection.kt
@@ -41,9 +41,12 @@ class QiqTemplatePathInspection : LocalInspectionTool() {
 
         val name = call.name?.takeIf { it.isNotEmpty() } ?: return
         if (name !in TEMPLATE_FUNCTIONS) return
-        // `$foo->render(...)` is some other object's method; only `$this->...`
-        // (and bare calls) reference a Qiq template.
-        if (call is MethodReference && (call.classReference as? Variable)?.name != "this") return
+        // Bare calls (`render('...')`) and the injected static directive
+        // (`\QiqRuntimeFunctions::extends('...')`) are template calls. An
+        // *instance* call is only one when the receiver is `$this`; skip
+        // `$other->render(...)`, which is some unrelated object's method.
+        val receiver = (call as? MethodReference)?.classReference
+        if (receiver is Variable && receiver.name != "this") return
 
         val arg = call.parameterList?.parameters?.firstOrNull() as? StringLiteralExpression ?: return
         val path = arg.contents

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/settings/QiqSettingService.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/settings/QiqSettingService.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.roots.ProjectFileIndex
@@ -12,6 +13,7 @@ import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
 import io.github.jingu.idea_qiq_plugin.util.QiqComposerVersionResolver
 import java.io.File
+import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.max
 
@@ -108,6 +110,55 @@ class QiqSettingsService(private val project: Project) : PersistentStateComponen
     }
 
     /**
+     * The template root for a Qiq root-absolute path (one written with a
+     * leading `/`, e.g. `setLayout('/layout/base')`, which Qiq resolves from
+     * the engine's template directory rather than the current file's folder).
+     *
+     * [resolveTemplateRoots] is content-driven and deliberately favours the
+     * dense template sub-directories near [contextFile], so it never yields the
+     * shared parent that a `/`-path is relative to. This walks up instead: from
+     * the file's folder toward the content root, ascending only while the next
+     * parent stays *inside* the template tree — i.e. it has no non-template
+     * sibling directory. The walk stops at the first parent that mixes in a
+     * non-template directory (e.g. `qiq/` holding both `template/` and a
+     * `helper/` of plain PHP), so the base lands on `template/` rather than
+     * climbing to `qiq/` or `var/`.
+     *
+     * Returns null when the file is outside any content root or its own folder
+     * does not look like a template directory.
+     */
+    fun resolveTemplateBase(contextFile: VirtualFile): VirtualFile? {
+        val key = CacheKey(contextFile.path)
+        baseCacheMap[key]?.let { return it.orElse(null) }
+        val computed = computeTemplateBase(contextFile)
+        baseCacheMap[key] = Optional.ofNullable(computed)
+        return computed
+    }
+
+    private fun computeTemplateBase(contextFile: VirtualFile): VirtualFile? {
+        // Upper bound for the ascent; the sibling-boundary check below is the
+        // real stop, this just guarantees we never climb past the project.
+        val stop = ProjectFileIndex.getInstance(project).getContentRootForFile(contextFile)
+            ?: project.basePath?.let { LocalFileSystem.getInstance().findFileByPath(it) }
+        var cur = (if (contextFile.isDirectory) contextFile else contextFile.parent) ?: return null
+        if (!Resolver.looksLikeTemplateDir(cur, state)) return null
+        var base = cur
+        var depth = 0
+        while (depth <= state.maxAscendDepth) {
+            val parent = cur.parent ?: break
+            if (parent == stop) break
+            // Ascend into the parent only while every one of its sub-directories
+            // is itself template content; a non-template sibling marks the edge
+            // of the template tree, which is the Qiq root a `/`-path uses.
+            if (!Resolver.allChildDirsLookLikeTemplates(parent, state)) break
+            base = parent
+            cur = parent
+            depth++
+        }
+        return base
+    }
+
+    /**
      * Returns the qiq/qiq major version declared in composer.lock for the
      * content root that owns [contextFile]. Falls back to 3 when the lock
      * file is missing, the package is not present, or the version string is
@@ -147,6 +198,9 @@ class QiqSettingsService(private val project: Project) : PersistentStateComponen
     // Same rationale as composerLockCache: resolveTemplateRoots is called
     // from completion/navigation contributors running on parallel ReadActions.
     private val cacheMap = ConcurrentHashMap<CacheKey, List<VirtualFile>>()
+    // resolveTemplateBase is hit on every completion keystroke; cache its
+    // result (Optional because ConcurrentHashMap forbids null values).
+    private val baseCacheMap = ConcurrentHashMap<CacheKey, Optional<VirtualFile>>()
 
     private fun getCached(contextFile: VirtualFile): List<VirtualFile> =
         cacheMap[CacheKey(contextFile.path)] ?: emptyList()
@@ -249,6 +303,46 @@ class QiqSettingsService(private val project: Project) : PersistentStateComponen
                 breadth = subdirsWithQiq.size,
                 layoutHints = layoutHints
             )
+        }
+
+        // Used by resolveTemplateBase's ascent: a directory "looks like" a
+        // template directory once its subtree yields a file with Qiq tokens.
+        // Cheap by design — only candidate-extension files are read, and the
+        // walk stops at the first token hit (or after LOOKS_LIKE_FILE_CAP files
+        // for a directory that is plain PHP / not a template root).
+        private const val LOOKS_LIKE_FILE_CAP = 80
+
+        fun looksLikeTemplateDir(dir: VirtualFile, st: State): Boolean {
+            var scanned = 0
+
+            fun visit(d: VirtualFile): Boolean {
+                for (c in d.children.orEmpty()) {
+                    ProgressManager.checkCanceled()
+                    if (scanned >= LOOKS_LIKE_FILE_CAP) return false
+                    if (c.isDirectory) {
+                        if (visit(c)) return true
+                        continue
+                    }
+                    val name = c.name.lowercase()
+                    if (st.candidateExtensions.none { name.endsWith(it) }) continue
+                    scanned++
+                    val text = runCatching { VfsUtilCore.loadText(c) }.getOrNull()?.let {
+                        if (it.length > st.maxBytesPerFile) it.substring(0, st.maxBytesPerFile) else it
+                    } ?: continue
+                    if (countQiqTokens(text) > 0) return true
+                }
+                return false
+            }
+            return visit(dir)
+        }
+
+        // True when [dir] has at least one sub-directory and every one of them
+        // is template content. Used to decide whether ascending into [dir]
+        // stays inside the template tree (no non-template sibling like helper/).
+        fun allChildDirsLookLikeTemplates(dir: VirtualFile, st: State): Boolean {
+            val childDirs = dir.children.orEmpty().filter { it.isDirectory }
+            if (childDirs.isEmpty()) return false
+            return childDirs.all { looksLikeTemplateDir(it, st) }
         }
 
         private fun countQiqTokens(text: String): Int {

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/settings/QiqSettingService.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/settings/QiqSettingService.kt
@@ -13,7 +13,6 @@ import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
 import io.github.jingu.idea_qiq_plugin.util.QiqComposerVersionResolver
 import java.io.File
-import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.max
 
@@ -129,9 +128,12 @@ class QiqSettingsService(private val project: Project) : PersistentStateComponen
      */
     fun resolveTemplateBase(contextFile: VirtualFile): VirtualFile? {
         val key = CacheKey(contextFile.path)
-        baseCacheMap[key]?.let { return it.orElse(null) }
-        val computed = computeTemplateBase(contextFile)
-        baseCacheMap[key] = Optional.ofNullable(computed)
+        baseCacheMap[key]?.let { return it }
+        // Cache only a positive result; a null base means the file is not (yet)
+        // inside a template tree, and recomputing lets it pick up once it is —
+        // mirrors how resolveTemplateRoots declines to cache an empty result.
+        val computed = computeTemplateBase(contextFile) ?: return null
+        baseCacheMap[key] = computed
         return computed
     }
 
@@ -198,9 +200,9 @@ class QiqSettingsService(private val project: Project) : PersistentStateComponen
     // Same rationale as composerLockCache: resolveTemplateRoots is called
     // from completion/navigation contributors running on parallel ReadActions.
     private val cacheMap = ConcurrentHashMap<CacheKey, List<VirtualFile>>()
-    // resolveTemplateBase is hit on every completion keystroke; cache its
-    // result (Optional because ConcurrentHashMap forbids null values).
-    private val baseCacheMap = ConcurrentHashMap<CacheKey, Optional<VirtualFile>>()
+    // resolveTemplateBase is hit on every completion keystroke; cache the
+    // positive result (a null base is intentionally left uncached).
+    private val baseCacheMap = ConcurrentHashMap<CacheKey, VirtualFile>()
 
     private fun getCached(contextFile: VirtualFile): List<VirtualFile> =
         cacheMap[CacheKey(contextFile.path)] ?: emptyList()

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -84,6 +84,13 @@
                 language="PHP"
                 implementationClass="io.github.jingu.idea_qiq_plugin.completion.QiqHelperCompletionContributor"/>
 
+        <!-- Complete template paths in setLayout()/render()/extends()/include()
+             arguments, listing files under the resolved template roots with the
+             Qiq extension stripped. Pairs with the path Go to Declaration. -->
+        <completion.contributor
+                language="PHP"
+                implementationClass="io.github.jingu.idea_qiq_plugin.completion.QiqTemplatePathCompletionContributor"/>
+
         <!-- ElementManipulators: required for refactorings (Rename, Move, etc.)
              to propagate edits made inside the injected PHP back to the Qiq host. -->
         <lang.elementManipulator

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -56,6 +56,19 @@
         <psi.referenceContributor
                 implementation="io.github.jingu.idea_qiq_plugin.navigation.QiqReferenceContributor"/>
 
+        <!-- Warn when setLayout()/render()/extends()/include() reference a
+             template that does not exist. Uses the same resolver as Go to
+             Declaration, so a path is flagged exactly when Cmd/Ctrl+click would
+             fail to navigate. Only plain string literals are checked. -->
+        <localInspection
+                language="PHP"
+                implementationClass="io.github.jingu.idea_qiq_plugin.inspection.QiqTemplatePathInspection"
+                bundle="messages.QiqBundle"
+                groupKey="inspection.group.qiq"
+                key="inspection.template.path.name"
+                enabledByDefault="true"
+                level="WARNING"/>
+
         <!-- Helper-call navigation: jump from `{{ myHelper(...) }}` /
              `{{ $this->myHelper(...) }}` to the PHP class registered via
              HelperLocator::set(). Implemented as a GotoDeclarationHandler

--- a/src/main/resources/messages/QiqBundle.properties
+++ b/src/main/resources/messages/QiqBundle.properties
@@ -15,3 +15,7 @@ settings.qiq.helper.bootstrap.group=Helper Locator bootstrap files
 settings.qiq.helper.bootstrap.comment=Add the PHP file(s) that register Qiq helpers via $locator->set('name', closure). The closure's declared return type or return new ClassName(...) supplies the navigation target for {{ helperName(...) }} / {{ $this->helperName(...) }} in templates.
 settings.qiq.helper.bootstrap.empty=No bootstrap files. Click + to choose a PHP file that calls $locator->set(...).
 settings.qiq.helper.bootstrap.chooser.title=Select Qiq Helper Bootstrap Files
+
+inspection.group.qiq=Qiq
+inspection.template.path.name=Qiq template path
+inspection.template.path.missing=Qiq template not found: ''{0}''

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/completion/QiqTemplatePathCompletionContributorTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/completion/QiqTemplatePathCompletionContributorTest.kt
@@ -1,0 +1,53 @@
+package io.github.jingu.idea_qiq_plugin.completion
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Unit tests for the pure extension-stripping helper that turns a
+ * root-relative template file path into the path users type in
+ * `setLayout('...')` / `render('...')` etc.
+ *
+ * The VFS walk and completion firing are exercised manually / by the
+ * planned HeavyPlatformTestCase integration suite.
+ */
+class QiqTemplatePathCompletionContributorTest {
+
+    private val exts = listOf(".qiq.php", ".qiq", ".php")
+
+    @Test
+    fun stripsLongestMatchingExtensionFirst() {
+        // `.qiq.php` must win over `.php`, otherwise a dangling `.qiq` is left.
+        assertEquals(
+            "layout/base",
+            QiqTemplatePathCompletionContributor.stripTemplateExtension("layout/base.qiq.php", exts),
+        )
+    }
+
+    @Test
+    fun stripsPlainQiqAndPhpExtensions() {
+        assertEquals("partials/menu", QiqTemplatePathCompletionContributor.stripTemplateExtension("partials/menu.qiq", exts))
+        assertEquals("page/index", QiqTemplatePathCompletionContributor.stripTemplateExtension("page/index.php", exts))
+    }
+
+    @Test
+    fun returnsNullForNonTemplateFiles() {
+        assertNull(QiqTemplatePathCompletionContributor.stripTemplateExtension("assets/app.css", exts))
+        assertNull(QiqTemplatePathCompletionContributor.stripTemplateExtension("README.md", exts))
+    }
+
+    @Test
+    fun isCaseInsensitiveOnExtension() {
+        assertEquals("Page/Home", QiqTemplatePathCompletionContributor.stripTemplateExtension("Page/Home.PHP", exts))
+    }
+
+    @Test
+    fun respectsConfiguredExtensionOrder() {
+        // With only ".php" configured, a ".qiq.php" file keeps its ".qiq" stem.
+        assertEquals(
+            "layout/base.qiq",
+            QiqTemplatePathCompletionContributor.stripTemplateExtension("layout/base.qiq.php", listOf(".php")),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Completes template paths in the first string argument of Qiq's template-referencing calls — `setLayout('...')`, `render('...')`, `extends('...')`, `include('...')` — inside Qiq templates. Pairs with the existing Go to Declaration on those same arguments.

- New `QiqTemplatePathCompletionContributor` (PHP `completion.contributor`): when the caret is in the first string arg of one of those calls in a Qiq file, offers the template files found under `QiqSettingsService.resolveTemplateRoots(contextFile)` as root-relative paths with the Qiq extension stripped (`layout/base.qiq.php` → `layout/base`).
- Sets the prefix matcher to the in-quote text before the caret so partial paths like `layout/ba` match/replace correctly.
- Recursive VFS walk is capped (2000 entries) and honors `ProgressManager.checkCanceled()`.

## Test plan
- [x] `./gradlew test` — incl. new `QiqTemplatePathCompletionContributorTest` (pure `stripTemplateExtension` cases: longest-suffix-first, `.qiq`/`.php`, non-templates, case-insensitivity, configured order)
- [x] `./gradlew buildPlugin`
- [ ] Manual: type inside `{{ setLayout('') }}` / `render('')` → available template paths offered

## Notes
- **Stacked on #19** (`feat/helper-completion`); base will be retargeted to `develop` once #19 merges. The diff here is the single template-path commit.
- As with helper completion, the completion firing path needs an indexed `CodeInsightTestFixture` (heavy test) and is deferred to the planned HeavyPlatformTestCase integration suite; the pure path logic is unit-tested here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)