### PR TITLE
feat: add code insight for Qiq helper calls (parameter info, argument inspection, quick docs)

### DIFF
--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/helper/QiqHelperTargets.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/helper/QiqHelperTargets.kt
@@ -2,6 +2,9 @@ package io.github.jingu.idea_qiq_plugin.helper
 
 import com.intellij.openapi.project.Project
 import com.jetbrains.php.lang.psi.elements.Function
+import com.jetbrains.php.lang.psi.elements.FunctionReference
+import com.jetbrains.php.lang.psi.elements.MethodReference
+import com.jetbrains.php.lang.psi.elements.Variable
 
 /**
  * Resolves a Qiq helper name to the callable PHP declaration(s) it dispatches
@@ -25,4 +28,14 @@ object QiqHelperTargets {
         targets.addAll(QiqHelpersClassResolver.getInstance(project).resolve(name))
         return targets
     }
+
+    /**
+     * Whether [call] is shaped like a Qiq helper dispatch: a bare call
+     * (`helper(...)`) or a `$this->helper(...)` method call. A call on any other
+     * receiver — `$other->helper(...)`, `Foo::helper(...)` — is an ordinary PHP
+     * call that merely shares a name with a helper, not a helper invocation, so
+     * the signature-based features must not treat it as one.
+     */
+    fun isHelperDispatch(call: FunctionReference): Boolean =
+        call !is MethodReference || (call.classReference as? Variable)?.name == "this"
 }

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/helper/QiqHelperTargets.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/helper/QiqHelperTargets.kt
@@ -1,0 +1,28 @@
+package io.github.jingu.idea_qiq_plugin.helper
+
+import com.intellij.openapi.project.Project
+import com.jetbrains.php.lang.psi.elements.Function
+
+/**
+ * Resolves a Qiq helper name to the callable PHP declaration(s) it dispatches
+ * to, across both supported styles:
+ *  - 1.x HelperLocator: the registered class's `__invoke` ([QiqHelperRegistry]).
+ *  - 2.x/3.x: a public method on a `Qiq\Helpers` subclass ([QiqHelpersClassResolver]).
+ *
+ * Shared by every consumer that needs the helper's *signature* — parameter
+ * info, the argument inspection, and quick documentation — so they always agree
+ * on what a call resolves to. (Go to Declaration resolves separately because it
+ * also offers the class itself as a fallback navigation target.)
+ */
+object QiqHelperTargets {
+
+    /** Every callable target for [name]; empty when it is not a known helper. */
+    fun functions(project: Project, name: String): List<Function> {
+        val targets = mutableListOf<Function>()
+        QiqHelperRegistry.getInstance(project).resolveClasses(name)
+            .mapNotNull { it.findMethodByName("__invoke") }
+            .forEach(targets::add)
+        targets.addAll(QiqHelpersClassResolver.getInstance(project).resolve(name))
+        return targets
+    }
+}

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inspection/QiqHelperArgumentsInspection.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inspection/QiqHelperArgumentsInspection.kt
@@ -1,0 +1,225 @@
+package io.github.jingu.idea_qiq_plugin.inspection
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import com.jetbrains.php.lang.psi.elements.Function
+import com.jetbrains.php.lang.psi.elements.FunctionReference
+import com.jetbrains.php.lang.psi.elements.MethodReference
+import com.jetbrains.php.lang.psi.elements.Parameter
+import com.jetbrains.php.lang.psi.elements.ParameterList
+import com.jetbrains.php.lang.psi.elements.PhpTypedElement
+import com.jetbrains.php.lang.psi.resolve.types.PhpType
+import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor
+import io.github.jingu.idea_qiq_plugin.helper.QiqHelperRegistry
+import io.github.jingu.idea_qiq_plugin.helper.QiqHelpersClassResolver
+import io.github.jingu.idea_qiq_plugin.lang.QiqInjectionSupport
+import io.github.jingu.idea_qiq_plugin.settings.QiqSettingsService
+import io.github.jingu.idea_qiq_plugin.ui.QiqBundle
+
+/**
+ * Validates Qiq helper calls inside templates against the resolved helper
+ * target's signature: the number of arguments, and the type of each positional
+ * argument.
+ *
+ * PhpStorm's own argument inspections never fire here: the injected
+ * `helper(...)` is an unresolved global call (Qiq dispatches helpers at
+ * runtime), so there is no declaration for the platform to check against.
+ * This inspection compares the call to the same target
+ * [QiqHelperGotoDeclarationHandler] resolves — a 1.x helper class's `__invoke`,
+ * or a 2.x/3.x `Qiq\Helpers` subclass method.
+ *
+ * Both checks are conservative — they only report what is unambiguous, so a
+ * false positive never fires:
+ *  - count: skipped when named arguments or spread (`...`) make the positional
+ *    count meaningless; with several resolved targets a call is flagged only
+ *    when it is invalid for every one.
+ *  - type: only when exactly one target resolves, and only for a positional
+ *    argument whose inferred type and the parameter's declared type are both
+ *    fully known (anything `mixed` / unresolved is left alone). Compatibility
+ *    is delegated to PhpStorm's own [PhpType.isConvertibleFromGlobal], so
+ *    inheritance, unions, nullables and scalar widening are honoured.
+ */
+class QiqHelperArgumentsInspection : LocalInspectionTool() {
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
+        object : PhpElementVisitor() {
+            override fun visitPhpFunctionCall(reference: FunctionReference) = inspectCall(reference, holder)
+
+            override fun visitPhpMethodReference(reference: MethodReference) = inspectCall(reference, holder)
+        }
+
+    private fun inspectCall(call: FunctionReference, holder: ProblemsHolder) {
+        if (!QiqInjectionSupport.isInQiqFile(call)) return
+
+        val name = call.name?.takeIf { it.isNotEmpty() } ?: return
+        val targets = resolveHelperTargets(call, name)
+        if (targets.isEmpty()) return
+
+        val parameterList = call.parameterList ?: return
+        // Named / spread arguments make positional matching meaningless.
+        if (hasUncountableArgument(parameterList.text)) return
+
+        val args = parameterList.parameters
+        if (checkArgumentCount(name, args.size, targets, parameterList, holder)) return
+
+        // Type-check only against a single unambiguous target.
+        targets.singleOrNull()?.let { checkArgumentTypes(name, args, it, call.project, holder) }
+    }
+
+    /** @return true when a count problem was reported (skip the type pass then). */
+    private fun checkArgumentCount(
+        name: String,
+        argCount: Int,
+        targets: List<Function>,
+        parameterList: ParameterList,
+        holder: ProblemsHolder,
+    ): Boolean {
+        val arity = Arity.of(targets)
+        val message = when {
+            argCount < arity.minRequired ->
+                QiqBundle.message("inspection.helper.argcount.few", name, arity.minRequired, argCount)
+            arity.maxAllowed != null && argCount > arity.maxAllowed ->
+                QiqBundle.message("inspection.helper.argcount.many", name, arity.maxAllowed, argCount)
+            else -> return false
+        }
+        holder.registerProblem(parameterList, message)
+        return true
+    }
+
+    private fun checkArgumentTypes(
+        name: String,
+        args: Array<PsiElement>,
+        target: Function,
+        project: Project,
+        holder: ProblemsHolder,
+    ) {
+        val params = target.parameters
+        // Under strict_types, a non-nullable scalar parameter rejects null even
+        // though PhpStorm treats null as loosely convertible to a scalar.
+        val strict = QiqSettingsService.getInstance(project).isStrictTypesEnabled()
+        for (i in args.indices) {
+            val param = params.getOrNull(i) ?: break
+            if (param.isVariadic) break // the variadic tail accepts any extra args
+
+            val expected = param.declaredType.global(project)
+            if (isUncheckable(expected)) continue
+
+            val arg = args[i] as? PhpTypedElement ?: continue
+            val actual = arg.globalType
+            if (isUncheckable(actual)) continue
+
+            val mismatch = !expected.isConvertibleFromGlobal(project, actual) ||
+                (strict && isNull(actual) && !isNullable(expected))
+            if (mismatch) {
+                holder.registerProblem(
+                    arg,
+                    QiqBundle.message(
+                        "inspection.helper.argtype.mismatch",
+                        i + 1, name, present(expected), present(actual),
+                    ),
+                )
+            }
+        }
+    }
+
+    private fun resolveHelperTargets(call: FunctionReference, name: String): List<Function> {
+        val project = call.project
+        val targets = mutableListOf<Function>()
+        QiqHelperRegistry.getInstance(project).resolveClasses(name)
+            .mapNotNull { it.findMethodByName("__invoke") }
+            .forEach(targets::add)
+        targets.addAll(QiqHelpersClassResolver.getInstance(project).resolve(name))
+        return targets
+    }
+
+    /**
+     * The accepted argument-count window across all resolved targets: the call
+     * is valid when its count is `>= minRequired` and (if bounded) `<= maxAllowed`.
+     * A variadic target makes the upper bound unbounded ([maxAllowed] = null).
+     */
+    private data class Arity(val minRequired: Int, val maxAllowed: Int?) {
+        companion object {
+            fun of(targets: List<Function>): Arity {
+                val minRequired = targets.minOf { requiredCount(it) }
+                val maxAllowed = if (targets.any(::hasVariadic)) null else targets.maxOf { it.parameters.size }
+                return Arity(minRequired, maxAllowed)
+            }
+
+            private fun requiredCount(function: Function): Int =
+                function.parameters.count { !it.isOptional && !it.isVariadic }
+
+            private fun hasVariadic(function: Function): Boolean =
+                function.parameters.any(Parameter::isVariadic)
+        }
+    }
+
+    companion object {
+        /** A type we cannot reliably compare — no constraint, or not fully inferred. */
+        private fun isUncheckable(type: PhpType): Boolean =
+            type.isEmpty || type.hasUnknown() || type.types.any { it == PhpType._MIXED }
+
+        /** The value is exactly `null` (e.g. the `null` literal), with no other type. */
+        private fun isNull(type: PhpType): Boolean =
+            type.types.isNotEmpty() && type.types.all { it == PhpType._NULL }
+
+        /** The parameter declares it accepts null (`?T` / a `null` union / mixed). */
+        private fun isNullable(type: PhpType): Boolean =
+            type.types.any { it == PhpType._NULL || it == PhpType._MIXED }
+
+        private fun present(type: PhpType): String = type.toString().removePrefix("\\")
+
+        /**
+         * True when [parameterListText] (the call's `( ... )`) contains a
+         * top-level named argument (`name:`) or a spread (`...`), which make a
+         * positional count unreliable. String literals and nested
+         * `()` / `[]` / `{}` are ignored so only argument-level syntax counts.
+         *
+         * Pure text logic, unit-tested independently of PSI.
+         */
+        fun hasUncountableArgument(parameterListText: String): Boolean {
+            val text = parameterListText.trim()
+            // The PSI text may or may not include the wrapping parentheses;
+            // arguments sit one level deeper when it does.
+            val argDepth = if (text.startsWith("(")) 1 else 0
+            var depth = 0
+            var i = 0
+            while (i < text.length) {
+                when (val c = text[i]) {
+                    '\'', '"' -> {
+                        i = skipString(text, i, c)
+                        continue
+                    }
+                    '(', '[', '{' -> depth++
+                    ')', ']', '}' -> depth--
+                    '.' -> if (depth == argDepth && text.startsWith("...", i)) return true
+                    ':' -> {
+                        // A single top-level colon separates `name: value`.
+                        // `::` (static access) and ternary colons nested in an
+                        // argument are excluded by the depth / double-colon guard.
+                        val prev = text.getOrNull(i - 1)
+                        val next = text.getOrNull(i + 1)
+                        if (depth == argDepth && prev != ':' && next != ':') return true
+                    }
+                }
+                i++
+            }
+            return false
+        }
+
+        /** Returns the index just past the closing quote of the literal opened at [start]. */
+        private fun skipString(text: String, start: Int, quote: Char): Int {
+            var i = start + 1
+            while (i < text.length) {
+                when (text[i]) {
+                    '\\' -> i++ // skip the escaped char
+                    quote -> return i + 1
+                }
+                i++
+            }
+            return i
+        }
+    }
+}

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inspection/QiqHelperArgumentsInspection.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inspection/QiqHelperArgumentsInspection.kt
@@ -13,8 +13,7 @@ import com.jetbrains.php.lang.psi.elements.ParameterList
 import com.jetbrains.php.lang.psi.elements.PhpTypedElement
 import com.jetbrains.php.lang.psi.resolve.types.PhpType
 import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor
-import io.github.jingu.idea_qiq_plugin.helper.QiqHelperRegistry
-import io.github.jingu.idea_qiq_plugin.helper.QiqHelpersClassResolver
+import io.github.jingu.idea_qiq_plugin.helper.QiqHelperTargets
 import io.github.jingu.idea_qiq_plugin.lang.QiqInjectionSupport
 import io.github.jingu.idea_qiq_plugin.settings.QiqSettingsService
 import io.github.jingu.idea_qiq_plugin.ui.QiqBundle
@@ -55,7 +54,7 @@ class QiqHelperArgumentsInspection : LocalInspectionTool() {
         if (!QiqInjectionSupport.isInQiqFile(call)) return
 
         val name = call.name?.takeIf { it.isNotEmpty() } ?: return
-        val targets = resolveHelperTargets(call, name)
+        val targets = QiqHelperTargets.functions(call.project, name)
         if (targets.isEmpty()) return
 
         val parameterList = call.parameterList ?: return
@@ -123,16 +122,6 @@ class QiqHelperArgumentsInspection : LocalInspectionTool() {
                 )
             }
         }
-    }
-
-    private fun resolveHelperTargets(call: FunctionReference, name: String): List<Function> {
-        val project = call.project
-        val targets = mutableListOf<Function>()
-        QiqHelperRegistry.getInstance(project).resolveClasses(name)
-            .mapNotNull { it.findMethodByName("__invoke") }
-            .forEach(targets::add)
-        targets.addAll(QiqHelpersClassResolver.getInstance(project).resolve(name))
-        return targets
     }
 
     /**

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inspection/QiqHelperArgumentsInspection.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inspection/QiqHelperArgumentsInspection.kt
@@ -52,6 +52,9 @@ class QiqHelperArgumentsInspection : LocalInspectionTool() {
 
     private fun inspectCall(call: FunctionReference, holder: ProblemsHolder) {
         if (!QiqInjectionSupport.isInQiqFile(call)) return
+        // Only bare / `$this->` calls dispatch a helper; `$other->renderAd(...)`
+        // and `Foo::renderAd(...)` merely share the name.
+        if (!QiqHelperTargets.isHelperDispatch(call)) return
 
         val name = call.name?.takeIf { it.isNotEmpty() } ?: return
         val targets = QiqHelperTargets.functions(call.project, name)
@@ -185,9 +188,13 @@ class QiqHelperArgumentsInspection : LocalInspectionTool() {
                     ')', ']', '}' -> depth--
                     '.' -> if (depth == argDepth && text.startsWith("...", i)) return true
                     ':' -> {
-                        // A single top-level colon separates `name: value`.
-                        // `::` (static access) and ternary colons nested in an
-                        // argument are excluded by the depth / double-colon guard.
+                        // A single top-level colon usually separates `name: value`.
+                        // `::` (static access) and colons nested inside brackets
+                        // are excluded by the double-colon / depth guard. A
+                        // top-level ternary `?:` colon is NOT distinguished and
+                        // also trips this — that only over-reports "uncountable",
+                        // conservatively skipping the count/type check, never a
+                        // false positive.
                         val prev = text.getOrNull(i - 1)
                         val next = text.getOrNull(i + 1)
                         if (depth == argDepth && prev != ':' && next != ':') return true

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inspection/QiqHelperArgumentsInspection.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inspection/QiqHelperArgumentsInspection.kt
@@ -112,8 +112,10 @@ class QiqHelperArgumentsInspection : LocalInspectionTool() {
         // though PhpStorm treats null as loosely convertible to a scalar.
         val strict = QiqSettingsService.getInstance(project).isStrictTypesEnabled()
         for (i in args.indices) {
-            val param = params.getOrNull(i) ?: break
-            if (param.isVariadic) break // the variadic tail accepts any extra args
+            // The i-th parameter, or — once past the fixed params — the trailing
+            // variadic, which accepts any *number* of further args but still
+            // constrains each to its (element) type, e.g. `int ...$xs`.
+            val param = params.getOrNull(i) ?: params.lastOrNull()?.takeIf(Parameter::isVariadic) ?: break
 
             val expected = param.declaredType.global(project)
             if (isUncheckable(expected)) continue

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inspection/QiqHelperArgumentsInspection.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inspection/QiqHelperArgumentsInspection.kt
@@ -79,13 +79,22 @@ class QiqHelperArgumentsInspection : LocalInspectionTool() {
         parameterList: ParameterList,
         holder: ProblemsHolder,
     ): Boolean {
+        // Valid as soon as one target accepts the count. Checking per target (not
+        // just the global min/max window) catches a count that lands in the gap
+        // between disjoint overloads — invalid for every target yet inside
+        // [minRequired..maxAllowed].
+        if (targets.any { Arity.accepts(it, argCount) }) return false
+
         val arity = Arity.of(targets)
         val message = when {
             argCount < arity.minRequired ->
                 QiqBundle.message("inspection.helper.argcount.few", name, arity.minRequired, argCount)
             arity.maxAllowed != null && argCount > arity.maxAllowed ->
                 QiqBundle.message("inspection.helper.argcount.many", name, arity.maxAllowed, argCount)
-            else -> return false
+            else ->
+                // In the overload gap: accepted by no target, yet within the
+                // global window, so neither "too few" nor "too many" fits.
+                QiqBundle.message("inspection.helper.argcount.invalid", name, argCount)
         }
         holder.registerProblem(parameterList, message)
         return true
@@ -139,6 +148,11 @@ class QiqHelperArgumentsInspection : LocalInspectionTool() {
                 val maxAllowed = if (targets.any(::hasVariadic)) null else targets.maxOf { it.parameters.size }
                 return Arity(minRequired, maxAllowed)
             }
+
+            /** Whether [function] alone accepts a call of [argCount] arguments. */
+            fun accepts(function: Function, argCount: Int): Boolean =
+                argCount >= requiredCount(function) &&
+                    (hasVariadic(function) || argCount <= function.parameters.size)
 
             private fun requiredCount(function: Function): Int =
                 function.parameters.count { !it.isOptional && !it.isVariadic }

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/navigation/QiqHelperDocumentationProvider.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/navigation/QiqHelperDocumentationProvider.kt
@@ -1,0 +1,54 @@
+package io.github.jingu.idea_qiq_plugin.navigation
+
+import com.intellij.lang.documentation.AbstractDocumentationProvider
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+import com.jetbrains.php.lang.psi.elements.FunctionReference
+import io.github.jingu.idea_qiq_plugin.helper.QiqHelperRegistry
+import io.github.jingu.idea_qiq_plugin.helper.QiqHelpersClassResolver
+import io.github.jingu.idea_qiq_plugin.lang.QiqInjectionSupport
+
+/**
+ * Points Quick Documentation (Ctrl/Cmd+Q, hover, and the doc PhpStorm appends
+ * to a warning tooltip) at the real declaration of a Qiq helper call.
+ *
+ * A helper call such as `{{ renderAd(...) }}` is an unresolved global call in
+ * the injected PHP — Qiq dispatches helpers at runtime — so PhpStorm has no
+ * symbol to document and renders an empty "Source: .../null". By supplying the
+ * resolved helper target as the documentation element (a 1.x helper class's
+ * `__invoke`, or a 2.x/3.x `Qiq\Helpers` subclass method — the same target
+ * [QiqHelperGotoDeclarationHandler] navigates to), the platform documents that
+ * method instead: its signature, PHPDoc and real source file.
+ */
+class QiqHelperDocumentationProvider : AbstractDocumentationProvider() {
+
+    override fun getCustomDocumentationElement(
+        editor: Editor,
+        file: PsiFile,
+        contextElement: PsiElement?,
+        targetOffset: Int,
+    ): PsiElement? {
+        val element = contextElement ?: return null
+        val call = PsiTreeUtil.getParentOfType(element, FunctionReference::class.java, false) ?: return null
+
+        // Only when the caret is on the call name, mirroring the helper goto.
+        val nameNode = call.nameNode ?: return null
+        if (!nameNode.textRange.contains(element.textRange)) return null
+
+        if (!QiqInjectionSupport.isInQiqFile(call)) return null
+
+        val name = call.name?.takeIf { it.isNotEmpty() } ?: return null
+        return resolveHelperTarget(call, name)
+    }
+
+    /** The single declaration to document: `__invoke` for a 1.x class, else a 2.x/3.x method. */
+    private fun resolveHelperTarget(call: FunctionReference, name: String): PsiElement? {
+        val project = call.project
+        QiqHelperRegistry.getInstance(project).resolveClasses(name)
+            .firstNotNullOfOrNull { it.findMethodByName("__invoke") }
+            ?.let { return it }
+        return QiqHelpersClassResolver.getInstance(project).resolve(name).firstOrNull()
+    }
+}

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/navigation/QiqHelperDocumentationProvider.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/navigation/QiqHelperDocumentationProvider.kt
@@ -37,6 +37,8 @@ class QiqHelperDocumentationProvider : AbstractDocumentationProvider() {
         if (!nameNode.textRange.contains(element.textRange)) return null
 
         if (!QiqInjectionSupport.isInQiqFile(call)) return null
+        // Only bare / `$this->` calls dispatch a helper, not `$other->name(...)`.
+        if (!QiqHelperTargets.isHelperDispatch(call)) return null
 
         val name = call.name?.takeIf { it.isNotEmpty() } ?: return null
         // Document the first resolved target (`__invoke` for a 1.x class, else

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/navigation/QiqHelperDocumentationProvider.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/navigation/QiqHelperDocumentationProvider.kt
@@ -6,8 +6,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.PsiTreeUtil
 import com.jetbrains.php.lang.psi.elements.FunctionReference
-import io.github.jingu.idea_qiq_plugin.helper.QiqHelperRegistry
-import io.github.jingu.idea_qiq_plugin.helper.QiqHelpersClassResolver
+import io.github.jingu.idea_qiq_plugin.helper.QiqHelperTargets
 import io.github.jingu.idea_qiq_plugin.lang.QiqInjectionSupport
 
 /**
@@ -40,15 +39,8 @@ class QiqHelperDocumentationProvider : AbstractDocumentationProvider() {
         if (!QiqInjectionSupport.isInQiqFile(call)) return null
 
         val name = call.name?.takeIf { it.isNotEmpty() } ?: return null
-        return resolveHelperTarget(call, name)
-    }
-
-    /** The single declaration to document: `__invoke` for a 1.x class, else a 2.x/3.x method. */
-    private fun resolveHelperTarget(call: FunctionReference, name: String): PsiElement? {
-        val project = call.project
-        QiqHelperRegistry.getInstance(project).resolveClasses(name)
-            .firstNotNullOfOrNull { it.findMethodByName("__invoke") }
-            ?.let { return it }
-        return QiqHelpersClassResolver.getInstance(project).resolve(name).firstOrNull()
+        // Document the first resolved target (`__invoke` for a 1.x class, else
+        // a 2.x/3.x method); for an overloaded name PhpStorm documents one.
+        return QiqHelperTargets.functions(call.project, name).firstOrNull()
     }
 }

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/navigation/QiqHelperParameterInfoHandler.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/navigation/QiqHelperParameterInfoHandler.kt
@@ -1,0 +1,134 @@
+package io.github.jingu.idea_qiq_plugin.navigation
+
+import com.intellij.lang.parameterInfo.CreateParameterInfoContext
+import com.intellij.lang.parameterInfo.ParameterInfoHandler
+import com.intellij.lang.parameterInfo.ParameterInfoUIContext
+import com.intellij.lang.parameterInfo.ParameterInfoUtils
+import com.intellij.lang.parameterInfo.UpdateParameterInfoContext
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+import com.jetbrains.php.lang.lexer.PhpTokenTypes
+import com.jetbrains.php.lang.psi.elements.Function
+import com.jetbrains.php.lang.psi.elements.FunctionReference
+import com.jetbrains.php.lang.psi.elements.Parameter
+import com.jetbrains.php.lang.psi.elements.ParameterList
+import io.github.jingu.idea_qiq_plugin.helper.QiqHelperRegistry
+import io.github.jingu.idea_qiq_plugin.helper.QiqHelpersClassResolver
+import io.github.jingu.idea_qiq_plugin.lang.QiqInjectionSupport
+
+/**
+ * Parameter-info (Ctrl/Cmd+P, and the auto popup after `(`) for Qiq helper
+ * calls inside templates.
+ *
+ * A helper call such as `{{= renderAd($this, '/x', [...]) }}` is injected as a
+ * bare global call `renderAd(...)` (or a `$this->renderAd(...)` method call),
+ * neither of which the PHP runtime can statically resolve — Qiq dispatches the
+ * name through HelperLocator / a `Qiq\Helpers` subclass. PhpStorm's own
+ * parameter-info handler therefore finds nothing and shows no hint. This
+ * handler fills that gap by rendering the signature of the resolved helper
+ * target — the same target [QiqHelperGotoDeclarationHandler] jumps to: a 1.x
+ * helper class's `__invoke`, or a 2.x/3.x `Qiq\Helpers` subclass method.
+ *
+ * The two handlers are mutually exclusive (PhpStorm resolves real functions,
+ * this one resolves helpers), so registration order does not matter.
+ */
+class QiqHelperParameterInfoHandler : ParameterInfoHandler<ParameterList, Function> {
+
+    override fun findElementForParameterInfo(context: CreateParameterInfoContext): ParameterList? {
+        val parameterList = parameterListAt(context.file, context.offset) ?: return null
+        val call = parameterList.parent as? FunctionReference ?: return null
+        if (!QiqInjectionSupport.isInQiqFile(call)) return null
+
+        val name = call.name?.takeIf { it.isNotEmpty() } ?: return null
+        val targets = resolveHelperTargets(call.project, name)
+        if (targets.isEmpty()) return null
+
+        context.itemsToShow = targets.toTypedArray()
+        return parameterList
+    }
+
+    override fun showParameterInfo(element: ParameterList, context: CreateParameterInfoContext) {
+        context.showHint(element, element.textRange.startOffset, this)
+    }
+
+    override fun findElementForUpdatingParameterInfo(context: UpdateParameterInfoContext): ParameterList? =
+        parameterListAt(context.file, context.offset)
+
+    override fun updateParameterInfo(parameterOwner: ParameterList, context: UpdateParameterInfoContext) {
+        // Dismiss if the caret left the call we started on.
+        if (context.parameterOwner != null && context.parameterOwner !== parameterOwner) {
+            context.removeHint()
+            return
+        }
+        val index = ParameterInfoUtils.getCurrentParameterIndex(
+            parameterOwner.node,
+            context.offset,
+            PhpTokenTypes.opCOMMA,
+        )
+        context.setCurrentParameter(index)
+    }
+
+    override fun updateUI(p: Function, context: ParameterInfoUIContext) {
+        val params = p.parameters
+        if (params.isEmpty()) {
+            context.setupUIComponentPresentation(
+                NO_PARAMETERS, -1, -1, false, false, false, context.defaultParameterColor,
+            )
+            return
+        }
+
+        val fragments = params.map(::renderParameter)
+        val text = fragments.joinToString(SEPARATOR)
+
+        // Highlight the fragment for the parameter the caret currently sits on.
+        val current = context.currentParameterIndex
+        var highlightStart = -1
+        var highlightEnd = -1
+        if (current in fragments.indices) {
+            highlightStart = fragments.take(current).sumOf { it.length + SEPARATOR.length }
+            highlightEnd = highlightStart + fragments[current].length
+        }
+
+        context.setupUIComponentPresentation(
+            text, highlightStart, highlightEnd, false, false, false, context.defaultParameterColor,
+        )
+    }
+
+    private fun parameterListAt(file: PsiFile, offset: Int): ParameterList? {
+        val element = file.findElementAt(offset) ?: file.findElementAt(offset - 1) ?: return null
+        // Caret inside the argument list.
+        PsiTreeUtil.getParentOfType(element, ParameterList::class.java, false)?.let { return it }
+        // Caret on the call name or the parentheses, which are siblings of the
+        // ParameterList under the call. Climb to the call and take its list.
+        return PsiTreeUtil.getParentOfType(element, FunctionReference::class.java, false)?.parameterList
+    }
+
+    /**
+     * Resolve [name] to the callable target(s) whose signature to show: a 1.x
+     * helper class's `__invoke` (classes without one are dropped — there is no
+     * signature to present) plus any 2.x/3.x helper methods.
+     */
+    private fun resolveHelperTargets(project: Project, name: String): List<Function> {
+        val targets = mutableListOf<Function>()
+        QiqHelperRegistry.getInstance(project).resolveClasses(name)
+            .mapNotNull { it.findMethodByName("__invoke") }
+            .forEach(targets::add)
+        targets.addAll(QiqHelpersClassResolver.getInstance(project).resolve(name))
+        return targets
+    }
+
+    private fun renderParameter(parameter: Parameter): String = buildString {
+        val type = parameter.declaredType.toString()
+        if (type.isNotEmpty()) append(type).append(' ')
+        if (parameter.isPassByRef) append('&')
+        if (parameter.isVariadic) append("...")
+        append('$').append(parameter.name)
+        parameter.defaultValuePresentation?.let { append(" = ").append(it) }
+    }
+
+    private companion object {
+        private const val SEPARATOR = ", "
+        private const val NO_PARAMETERS = "<no parameters>"
+    }
+}

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/navigation/QiqHelperParameterInfoHandler.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/navigation/QiqHelperParameterInfoHandler.kt
@@ -5,7 +5,6 @@ import com.intellij.lang.parameterInfo.ParameterInfoHandler
 import com.intellij.lang.parameterInfo.ParameterInfoUIContext
 import com.intellij.lang.parameterInfo.ParameterInfoUtils
 import com.intellij.lang.parameterInfo.UpdateParameterInfoContext
-import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.PsiTreeUtil
 import com.jetbrains.php.lang.lexer.PhpTokenTypes
@@ -13,8 +12,7 @@ import com.jetbrains.php.lang.psi.elements.Function
 import com.jetbrains.php.lang.psi.elements.FunctionReference
 import com.jetbrains.php.lang.psi.elements.Parameter
 import com.jetbrains.php.lang.psi.elements.ParameterList
-import io.github.jingu.idea_qiq_plugin.helper.QiqHelperRegistry
-import io.github.jingu.idea_qiq_plugin.helper.QiqHelpersClassResolver
+import io.github.jingu.idea_qiq_plugin.helper.QiqHelperTargets
 import io.github.jingu.idea_qiq_plugin.lang.QiqInjectionSupport
 
 /**
@@ -41,7 +39,7 @@ class QiqHelperParameterInfoHandler : ParameterInfoHandler<ParameterList, Functi
         if (!QiqInjectionSupport.isInQiqFile(call)) return null
 
         val name = call.name?.takeIf { it.isNotEmpty() } ?: return null
-        val targets = resolveHelperTargets(call.project, name)
+        val targets = QiqHelperTargets.functions(call.project, name)
         if (targets.isEmpty()) return null
 
         context.itemsToShow = targets.toTypedArray()
@@ -102,20 +100,6 @@ class QiqHelperParameterInfoHandler : ParameterInfoHandler<ParameterList, Functi
         // Caret on the call name or the parentheses, which are siblings of the
         // ParameterList under the call. Climb to the call and take its list.
         return PsiTreeUtil.getParentOfType(element, FunctionReference::class.java, false)?.parameterList
-    }
-
-    /**
-     * Resolve [name] to the callable target(s) whose signature to show: a 1.x
-     * helper class's `__invoke` (classes without one are dropped — there is no
-     * signature to present) plus any 2.x/3.x helper methods.
-     */
-    private fun resolveHelperTargets(project: Project, name: String): List<Function> {
-        val targets = mutableListOf<Function>()
-        QiqHelperRegistry.getInstance(project).resolveClasses(name)
-            .mapNotNull { it.findMethodByName("__invoke") }
-            .forEach(targets::add)
-        targets.addAll(QiqHelpersClassResolver.getInstance(project).resolve(name))
-        return targets
     }
 
     private fun renderParameter(parameter: Parameter): String = buildString {

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/navigation/QiqHelperParameterInfoHandler.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/navigation/QiqHelperParameterInfoHandler.kt
@@ -37,6 +37,8 @@ class QiqHelperParameterInfoHandler : ParameterInfoHandler<ParameterList, Functi
         val parameterList = parameterListAt(context.file, context.offset) ?: return null
         val call = parameterList.parent as? FunctionReference ?: return null
         if (!QiqInjectionSupport.isInQiqFile(call)) return null
+        // Only bare / `$this->` calls dispatch a helper, not `$other->name(...)`.
+        if (!QiqHelperTargets.isHelperDispatch(call)) return null
 
         val name = call.name?.takeIf { it.isNotEmpty() } ?: return null
         val targets = QiqHelperTargets.functions(call.project, name)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -9,6 +9,8 @@
     <depends>com.jetbrains.php</depends>
     <depends>com.intellij.modules.xml</depends>
 
+    <resource-bundle>messages.QiqBundle</resource-bundle>
+
     <extensions defaultExtensionNs="com.intellij">
         <fileType
                 name="Qiq"
@@ -63,7 +65,6 @@
         <localInspection
                 language="PHP"
                 implementationClass="io.github.jingu.idea_qiq_plugin.inspection.QiqTemplatePathInspection"
-                bundle="messages.QiqBundle"
                 groupKey="inspection.group.qiq"
                 key="inspection.template.path.name"
                 enabledByDefault="true"
@@ -80,6 +81,15 @@
         <gotoDeclarationHandler
                 implementation="io.github.jingu.idea_qiq_plugin.navigation.QiqHelperGotoDeclarationHandler"/>
 
+        <!-- Quick Documentation for helper calls. The injected `helper(...)` is
+             an unresolved global call, so PhpStorm shows an empty
+             "Source: .../null"; this points the doc at the resolved helper
+             target (1.x `__invoke` / 2.x-3.x method) so its signature and real
+             source file are shown instead. -->
+        <lang.documentationProvider
+                language="PHP"
+                implementationClass="io.github.jingu.idea_qiq_plugin.navigation.QiqHelperDocumentationProvider"/>
+
         <!-- Suppress "undefined function/method" warnings for helper calls
              the plugin can resolve. Qiq dispatches helpers through
              HelperLocator at runtime, so they have no static declaration in
@@ -88,6 +98,28 @@
         <lang.inspectionSuppressor
                 language="PHP"
                 implementationClass="io.github.jingu.idea_qiq_plugin.inspection.QiqHelperInspectionSuppressor"/>
+
+        <!-- Argument check for helper calls. PhpStorm cannot check the
+             arguments of an unresolved `helper(...)` call, so this compares the
+             call against the resolved helper target's signature (1.x `__invoke`
+             / 2.x-3.x method): argument count, plus the type of each positional
+             argument. Conservative — skipped for named/spread arguments and for
+             any argument whose type is not fully known. -->
+        <localInspection
+                language="PHP"
+                implementationClass="io.github.jingu.idea_qiq_plugin.inspection.QiqHelperArgumentsInspection"
+                groupKey="inspection.group.qiq"
+                key="inspection.helper.arguments.name"
+                enabledByDefault="true"
+                level="WARNING"/>
+
+        <!-- Parameter info (Ctrl/Cmd+P + the auto popup after `(`) for helper
+             calls. The injected `helper(...)` is an unresolved global call, so
+             PhpStorm's own handler shows nothing; this one renders the resolved
+             helper target's signature (1.x `__invoke` / 2.x-3.x method). -->
+        <codeInsight.parameterInfo
+                language="PHP"
+                implementationClass="io.github.jingu.idea_qiq_plugin.navigation.QiqHelperParameterInfoHandler"/>
 
         <!-- Complete custom helper names (1.x HelperLocator registrations +
              2.x/3.x Qiq\Helpers subclass methods) at call positions inside

--- a/src/main/resources/messages/QiqBundle.properties
+++ b/src/main/resources/messages/QiqBundle.properties
@@ -22,4 +22,5 @@ inspection.template.path.missing=Qiq template not found: ''{0}''
 inspection.helper.arguments.name=Qiq helper call arguments
 inspection.helper.argcount.few=Too few arguments to helper ''{0}'': expected at least {1}, got {2}
 inspection.helper.argcount.many=Too many arguments to helper ''{0}'': expected at most {1}, got {2}
+inspection.helper.argcount.invalid=Invalid number of arguments to helper ''{0}'': {1} matches none of its signatures
 inspection.helper.argtype.mismatch=Argument {0} of helper ''{1}'': expected {2}, got {3}

--- a/src/main/resources/messages/QiqBundle.properties
+++ b/src/main/resources/messages/QiqBundle.properties
@@ -19,3 +19,7 @@ settings.qiq.helper.bootstrap.chooser.title=Select Qiq Helper Bootstrap Files
 inspection.group.qiq=Qiq
 inspection.template.path.name=Qiq template path
 inspection.template.path.missing=Qiq template not found: ''{0}''
+inspection.helper.arguments.name=Qiq helper call arguments
+inspection.helper.argcount.few=Too few arguments to helper ''{0}'': expected at least {1}, got {2}
+inspection.helper.argcount.many=Too many arguments to helper ''{0}'': expected at most {1}, got {2}
+inspection.helper.argtype.mismatch=Argument {0} of helper ''{1}'': expected {2}, got {3}

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/inspection/QiqHelperArgumentsInspectionTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/inspection/QiqHelperArgumentsInspectionTest.kt
@@ -1,0 +1,54 @@
+package io.github.jingu.idea_qiq_plugin.inspection
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the pure argument-list scanner that decides whether a helper
+ * call's positional argument count can be trusted. Named arguments and spread
+ * (`...`) unpacking make the count unreliable, so the inspection skips them.
+ *
+ * The PSI text may or may not carry the wrapping parentheses, so both shapes
+ * are covered.
+ */
+class QiqHelperArgumentsInspectionTest {
+
+    private fun uncountable(text: String) =
+        QiqHelperArgumentsInspection.hasUncountableArgument(text)
+
+    @Test
+    fun plainPositionalArgsAreCountable() {
+        assertFalse(uncountable("(\$this, '/partial/ad/targeting', ['adLevel' => 'article'])"))
+        assertFalse(uncountable("\$this, '/p'")) // unwrapped shape
+        assertFalse(uncountable("()"))
+    }
+
+    @Test
+    fun namedArgumentIsUncountable() {
+        assertTrue(uncountable("(templatePath: '/p')"))
+        assertTrue(uncountable("\$this, name: \$x")) // unwrapped shape
+    }
+
+    @Test
+    fun spreadArgumentIsUncountable() {
+        assertTrue(uncountable("(...\$args)"))
+        assertTrue(uncountable("(\$this, ...\$rest)"))
+    }
+
+    @Test
+    fun colonInsideStringIsIgnored() {
+        assertFalse(uncountable("('https://example.com/path')"))
+    }
+
+    @Test
+    fun staticAccessColonsAreIgnored() {
+        assertFalse(uncountable("(\$this, Foo::BAR)"))
+    }
+
+    @Test
+    fun spreadNestedInArrayIsNotArgumentLevel() {
+        // `[...$a]` is array unpacking inside one argument, not a call spread.
+        assertFalse(uncountable("([...\$a], \$b)"))
+    }
+}


### PR DESCRIPTION
## Summary

Qiq ヘルパー呼び出しに対する **コードインサイト** を追加します。テンプレート内のヘルパー呼び出し（`{{ renderAd(...) }}` / `{{ $this->renderAd(...) }}`）は注入された PHP では未解決のグローバル呼び出しになるため、PhpStorm 標準のパラメータ情報・引数検査・クイックドキュメントはいずれも何も表示しません。本PRはこれを補い、ヘルパーが解決するターゲット（1.x の `__invoke` / 2.x-3.x の `Qiq\Helpers` サブクラスのメソッド — Go to Declaration と同じターゲット）から各機能を供給します。

`feat/helper-completion`（#19）に依存するためスタックしています（#19 マージ後に base を develop へ切り替え予定）。

## 追加機能

- **パラメータ情報**（Cmd/Ctrl+P・`(` 入力後の自動ポップアップ）— `QiqHelperParameterInfoHandler`
- **引数チェック inspection**（個数 + 各位置引数の型）— `QiqHelperArgumentsInspection`
  - 型互換性は PhpStorm の `PhpType.isConvertibleFromGlobal` に委譲（継承・union・nullable・スカラー拡大を尊重）
  - strict_types オプション有効時は「非nullable スカラーへの `null`」も警告（プラグイン設定に追従）
  - 保守的設計：named/spread 引数を含む呼び出しや、型が完全に確定しない（mixed/未解決）引数はスキップし、誤検知を出さない
- **クイックドキュメント**（Ctrl/Cmd+Q・ホバー）— `QiqHelperDocumentationProvider`
- 解決ロジックを `QiqHelperTargets` に集約し、3機能が常に同じターゲットを共有

## Test

- `QiqHelperArgumentsInspectionTest` — 純粋ロジック `hasUncountableArgument` の6ケース
- `./gradlew test` / `./gradlew buildPlugin` 緑
- 実機（PhpStorm + SPUR プロジェクト）でパラメータ情報・個数/型チェック・strict-null 切替・Ctrl+Q シグネチャ表示を確認済み

## Follow-up（別TODO）

- PSI/インデックス依存ロジック（Arity・型チェック・strict-null・パラメータ情報描画）の統合テスト整備

🤖 Generated with [Claude Code](https://claude.com/claude-code)
