### PR TITLE
feat: code folding for Qiq block directives (#27)

### DIFF
--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModel.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModel.kt
@@ -76,6 +76,14 @@ object QiqBlockModel {
         while (i < n - 1) {
             if (text[i] == '{' && text[i + 1] == '{') {
                 val closeStart = indexOfDoubleBrace(text, i + 2) ?: break
+                // If another `{{` opens before this one's `}}`, this opener is unclosed
+                // (e.g. a half-typed `{{ if (` mid-edit). Skip it and resume at the inner
+                // `{{` so the later, well-formed directives are still detected.
+                val nextOpen = indexOfDoubleOpen(text, i + 2)
+                if (nextOpen != null && nextOpen < closeStart) {
+                    i = nextOpen
+                    continue
+                }
                 val openStart = i
                 val openEnd = closeStart + 2
                 val inner = text.subSequence(i + 2, closeStart).toString().trim()
@@ -135,6 +143,15 @@ object QiqBlockModel {
         var j = from
         while (j < text.length - 1) {
             if (text[j] == '}' && text[j + 1] == '}') return j
+            j++
+        }
+        return null
+    }
+
+    private fun indexOfDoubleOpen(text: CharSequence, from: Int): Int? {
+        var j = from
+        while (j < text.length - 1) {
+            if (text[j] == '{' && text[j + 1] == '{') return j
             j++
         }
         return null

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModel.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModel.kt
@@ -95,12 +95,18 @@ object QiqBlockModel {
         val head = inner.takeWhile { !it.isWhitespace() && it != '(' && it != ':' }
 
         val openType = QiqBlockType.forOpenHead(head)
-        if (openType != null && (!openType.requiresColon || inner.contains(':'))) {
+        // Alternative syntax terminates the opener with a colon (`{{ if (...): }}`).
+        // Test the trailing colon, not any colon, so a ternary `?:` inside the
+        // condition does not turn a non-block `{{ if (...) }}` into a block opener.
+        if (openType != null && (!openType.requiresColon || inner.trimEnd().endsWith(':'))) {
             openers.addLast(Pending(openType, delimiter))
             return
         }
 
         val closeType = QiqBlockType.forCloseHead(head) ?: return
+        // setSection/setBlock are call-style, so their closers need parentheses;
+        // `{{ endSection }}` (no parens) is invalid PHP and is not a valid closer.
+        if ((closeType == QiqBlockType.SECTION || closeType == QiqBlockType.BLOCK) && '(' !in inner) return
         val matchIndex = openers.indexOfLast { it.type == closeType }
         if (matchIndex < 0) return // unmatched closer
 

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModel.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModel.kt
@@ -107,12 +107,16 @@ object QiqBlockModel {
         val head = inner.takeWhile { !it.isWhitespace() && it != '(' && it != ':' }
 
         val openType = QiqBlockType.forOpenHead(head)
-        // Every opener is a call/condition form, so it must contain '(' — this rejects
-        // bare `{{ if $x: }}` / `{{ setSection 'a' }}`. if/foreach/for additionally
-        // require the trailing alternative-syntax colon; testing the trailing colon
-        // (not any colon) keeps a ternary `?:` in the condition from being mistaken
-        // for one.
-        if (openType != null && '(' in inner && (!openType.requiresColon || inner.trimEnd().endsWith(':'))) {
+        // Every opener is a call/condition form whose '(' follows the head directly
+        // (whitespace allowed). Requiring the '(' right after the head rejects bare
+        // `{{ if $x: }}` / `{{ setSection 'a' }}` and avoids a false positive when an
+        // inner call supplies the '(' (e.g. `{{ if $x && foo(): }}`). if/foreach/for
+        // additionally require the trailing alternative-syntax colon; testing the
+        // trailing colon (not any colon) keeps a ternary `?:` from being mistaken for one.
+        if (openType != null &&
+            inner.substring(head.length).trimStart().startsWith("(") &&
+            (!openType.requiresColon || inner.trimEnd().endsWith(':'))
+        ) {
             openers.addLast(Pending(openType, delimiter))
             return
         }

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModel.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModel.kt
@@ -1,14 +1,18 @@
 package io.github.jingu.idea_qiq_plugin.block
 
 import com.intellij.openapi.util.TextRange
+import java.util.Locale
 
 /**
  * The Qiq block directives that come in opener/closer pairs.
  *
- * Mirrors the block set that [io.github.jingu.idea_qiq_plugin.editor.QiqEnterHandler]
- * already auto-closes. `if`/`foreach`/`for` use PHP alternative syntax, so an opener
- * is only a block when it is colon-terminated (`{{ if (...): }}`); `setSection` /
- * `setBlock` are call-style openers.
+ * Shares its directive set with [io.github.jingu.idea_qiq_plugin.editor.QiqEnterHandler]
+ * (which auto-closes the same blocks). `if`/`foreach`/`for` use PHP alternative syntax,
+ * so an opener is only a block when it is colon-terminated (`{{ if (...): }}`);
+ * `setSection` / `setBlock` are call-style openers. The exact opener/closer parsing
+ * here is deliberately stricter than the keyword set alone to avoid pairing
+ * syntactically invalid directives. Heads are matched case-insensitively, as PHP
+ * keywords and method names are.
  */
 enum class QiqBlockType(
     val openHead: String,
@@ -22,11 +26,11 @@ enum class QiqBlockType(
     BLOCK("setBlock", "endBlock", false);
 
     companion object {
-        private val byOpenHead = entries.associateBy { it.openHead }
-        private val byCloseHead = entries.associateBy { it.closeHead }
+        private val byOpenHead = entries.associateBy { it.openHead.lowercase(Locale.ROOT) }
+        private val byCloseHead = entries.associateBy { it.closeHead.lowercase(Locale.ROOT) }
 
-        fun forOpenHead(head: String): QiqBlockType? = byOpenHead[head]
-        fun forCloseHead(head: String): QiqBlockType? = byCloseHead[head]
+        fun forOpenHead(head: String): QiqBlockType? = byOpenHead[head.lowercase(Locale.ROOT)]
+        fun forCloseHead(head: String): QiqBlockType? = byCloseHead[head.lowercase(Locale.ROOT)]
     }
 }
 
@@ -95,18 +99,25 @@ object QiqBlockModel {
         val head = inner.takeWhile { !it.isWhitespace() && it != '(' && it != ':' }
 
         val openType = QiqBlockType.forOpenHead(head)
-        // Alternative syntax terminates the opener with a colon (`{{ if (...): }}`).
-        // Test the trailing colon, not any colon, so a ternary `?:` inside the
-        // condition does not turn a non-block `{{ if (...) }}` into a block opener.
-        if (openType != null && (!openType.requiresColon || inner.trimEnd().endsWith(':'))) {
+        // Every opener is a call/condition form, so it must contain '(' — this rejects
+        // bare `{{ if $x: }}` / `{{ setSection 'a' }}`. if/foreach/for additionally
+        // require the trailing alternative-syntax colon; testing the trailing colon
+        // (not any colon) keeps a ternary `?:` in the condition from being mistaken
+        // for one.
+        if (openType != null && '(' in inner && (!openType.requiresColon || inner.trimEnd().endsWith(':'))) {
             openers.addLast(Pending(openType, delimiter))
             return
         }
 
         val closeType = QiqBlockType.forCloseHead(head) ?: return
-        // setSection/setBlock are call-style, so their closers need parentheses;
-        // `{{ endSection }}` (no parens) is invalid PHP and is not a valid closer.
-        if ((closeType == QiqBlockType.SECTION || closeType == QiqBlockType.BLOCK) && '(' !in inner) return
+        // setSection/setBlock are call-style: only an empty-arg call closes them
+        // (`{{ endSection() }}`, optional trailing `;`). Anything else — no parens,
+        // or arguments — is invalid and must not pair.
+        if ((closeType == QiqBlockType.SECTION || closeType == QiqBlockType.BLOCK) &&
+            !isEmptyArgClose(inner, closeType)
+        ) {
+            return
+        }
         val matchIndex = openers.indexOfLast { it.type == closeType }
         if (matchIndex < 0) return // unmatched closer
 
@@ -115,6 +126,10 @@ object QiqBlockModel {
         while (openers.size > matchIndex) openers.removeLast()
         result.add(QiqBlockRange(closeType, opener.delimiter, delimiter))
     }
+
+    /** True if [inner] is an empty-arg call closer, e.g. `endSection()` / `endBlock() ;`. */
+    private fun isEmptyArgClose(inner: String, type: QiqBlockType): Boolean =
+        Regex("""(?i)${Regex.escape(type.closeHead)}\s*\(\s*\)\s*;?""").matches(inner)
 
     private fun indexOfDoubleBrace(text: CharSequence, from: Int): Int? {
         var j = from

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModel.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModel.kt
@@ -1,0 +1,123 @@
+package io.github.jingu.idea_qiq_plugin.block
+
+import com.intellij.openapi.util.TextRange
+
+/**
+ * The Qiq block directives that come in opener/closer pairs.
+ *
+ * Mirrors the block set that [io.github.jingu.idea_qiq_plugin.editor.QiqEnterHandler]
+ * already auto-closes. `if`/`foreach`/`for` use PHP alternative syntax, so an opener
+ * is only a block when it is colon-terminated (`{{ if (...): }}`); `setSection` /
+ * `setBlock` are call-style openers.
+ */
+enum class QiqBlockType(
+    val openHead: String,
+    val closeHead: String,
+    val requiresColon: Boolean,
+) {
+    IF("if", "endif", true),
+    FOREACH("foreach", "endforeach", true),
+    FOR("for", "endfor", true),
+    SECTION("setSection", "endSection", false),
+    BLOCK("setBlock", "endBlock", false);
+
+    companion object {
+        private val byOpenHead = entries.associateBy { it.openHead }
+        private val byCloseHead = entries.associateBy { it.closeHead }
+
+        fun forOpenHead(head: String): QiqBlockType? = byOpenHead[head]
+        fun forCloseHead(head: String): QiqBlockType? = byCloseHead[head]
+    }
+}
+
+/**
+ * A balanced pair of Qiq block directives.
+ *
+ * [open] and [close] are the `{{ ... }}` delimiter spans of the opener and closer.
+ */
+data class QiqBlockRange(
+    val type: QiqBlockType,
+    val open: TextRange,
+    val close: TextRange,
+) {
+    /** The block body: everything between the opener and closer delimiters. */
+    val bodyRange: TextRange get() = TextRange(open.endOffset, close.startOffset)
+
+    /** The whole block, from the start of the opener to the end of the closer. */
+    val fullRange: TextRange get() = TextRange(open.startOffset, close.endOffset)
+}
+
+/**
+ * Pairs Qiq block openers with their closers from raw template text.
+ *
+ * This is the shared foundation for folding, block matching, and the structure view.
+ * It is intentionally text-based (not PSI-based): the lexer flattens `{{ ... }}` into
+ * injection-host content, so the `if`/`endif` distinction only survives as text.
+ */
+object QiqBlockModel {
+
+    /**
+     * Scan [text] and return every balanced block pair, ordered by opener offset.
+     *
+     * Unbalanced directives (an opener with no closer, or a closer with no opener)
+     * are dropped rather than paired, so callers never see a broken range. Inner
+     * blocks left unclosed when their parent closes are dropped the same way.
+     */
+    fun computeBlockRanges(text: CharSequence): List<QiqBlockRange> {
+        val openers = ArrayDeque<Pending>()
+        val result = ArrayList<QiqBlockRange>()
+
+        var i = 0
+        val n = text.length
+        while (i < n - 1) {
+            if (text[i] == '{' && text[i + 1] == '{') {
+                val closeStart = indexOfDoubleBrace(text, i + 2) ?: break
+                val openStart = i
+                val openEnd = closeStart + 2
+                val inner = text.subSequence(i + 2, closeStart).toString().trim()
+                accept(inner, TextRange(openStart, openEnd), openers, result)
+                i = openEnd
+            } else {
+                i++
+            }
+        }
+
+        result.sortBy { it.open.startOffset }
+        return result
+    }
+
+    private fun accept(
+        inner: String,
+        delimiter: TextRange,
+        openers: ArrayDeque<Pending>,
+        result: MutableList<QiqBlockRange>,
+    ) {
+        val head = inner.takeWhile { !it.isWhitespace() && it != '(' && it != ':' }
+
+        val openType = QiqBlockType.forOpenHead(head)
+        if (openType != null && (!openType.requiresColon || inner.contains(':'))) {
+            openers.addLast(Pending(openType, delimiter))
+            return
+        }
+
+        val closeType = QiqBlockType.forCloseHead(head) ?: return
+        val matchIndex = openers.indexOfLast { it.type == closeType }
+        if (matchIndex < 0) return // unmatched closer
+
+        val opener = openers[matchIndex]
+        // Drop the matched opener and any inner blocks left unclosed above it.
+        while (openers.size > matchIndex) openers.removeLast()
+        result.add(QiqBlockRange(closeType, opener.delimiter, delimiter))
+    }
+
+    private fun indexOfDoubleBrace(text: CharSequence, from: Int): Int? {
+        var j = from
+        while (j < text.length - 1) {
+            if (text[j] == '}' && text[j + 1] == '}') return j
+            j++
+        }
+        return null
+    }
+
+    private data class Pending(val type: QiqBlockType, val delimiter: TextRange)
+}

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/editor/QiqFoldingBuilder.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/editor/QiqFoldingBuilder.kt
@@ -1,0 +1,43 @@
+package io.github.jingu.idea_qiq_plugin.editor
+
+import com.intellij.lang.ASTNode
+import com.intellij.lang.folding.FoldingBuilderEx
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.project.DumbAware
+import com.intellij.psi.PsiElement
+import io.github.jingu.idea_qiq_plugin.block.QiqBlockModel
+
+/**
+ * Folds Qiq block directives (`{{ if (...): }}` … `{{ endif }}`, `foreach`, `for`,
+ * `setSection`, `setBlock`) using the shared [QiqBlockModel].
+ *
+ * Only the block body is folded, so the opener and closer delimiters stay visible
+ * and a collapsed block reads as `{{ if (...): }}…{{ endif }}`. Single-line blocks
+ * are skipped — there is nothing useful to collapse.
+ */
+class QiqFoldingBuilder : FoldingBuilderEx(), DumbAware {
+
+    override fun buildFoldRegions(
+        root: PsiElement,
+        document: Document,
+        quick: Boolean,
+    ): Array<FoldingDescriptor> {
+        val node = root.node ?: return emptyArray()
+        val descriptors = ArrayList<FoldingDescriptor>()
+
+        for (block in QiqBlockModel.computeBlockRanges(document.charsSequence)) {
+            val body = block.bodyRange
+            if (body.isEmpty) continue
+            // Nothing to collapse if the opener and closer share a line.
+            if (document.getLineNumber(body.startOffset) == document.getLineNumber(body.endOffset)) continue
+            descriptors.add(FoldingDescriptor(node, body))
+        }
+
+        return descriptors.toTypedArray()
+    }
+
+    override fun getPlaceholderText(node: ASTNode): String = "…"
+
+    override fun isCollapsedByDefault(node: ASTNode): Boolean = false
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -45,6 +45,14 @@
         <typedHandler implementation="io.github.jingu.idea_qiq_plugin.editor.QiqTypedHandler"/>
         <enterHandlerDelegate implementation="io.github.jingu.idea_qiq_plugin.editor.QiqEnterHandler"/>
 
+        <!-- Code folding for Qiq block directives ({{ if }}/{{ endif }},
+             foreach, for, setSection, setBlock). Backed by the shared
+             block-range model so folding, block matching, and the structure
+             view all pair openers and closers the same way. -->
+        <lang.foldingBuilder
+                language="Qiq"
+                implementationClass="io.github.jingu.idea_qiq_plugin.editor.QiqFoldingBuilder"/>
+
         <!-- Color Settings Page -->
         <colorSettingsPage implementation="io.github.jingu.idea_qiq_plugin.ui.QiqColorSettingsPage"/>
 

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModelTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModelTest.kt
@@ -166,6 +166,13 @@ class QiqBlockModelTest {
     }
 
     @Test
+    fun openerParenthesisMustFollowHead() {
+        // A '(' from an inner call doesn't qualify: the opener's own '(' must follow
+        // the head, so `{{ if $x && foo(): }}` (no outer parens) is not a block.
+        assertTrue(ranges("{{ if ${'$'}x && foo(): }}body{{ endif }}").isEmpty())
+    }
+
+    @Test
     fun callStyleCloserMustBeEmptyArgCall() {
         // Only an empty-arg call closes a section/block; arguments are invalid.
         assertTrue(ranges("{{ setSection('a') }}x{{ endSection(${'$'}x) }}").isEmpty())

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModelTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModelTest.kt
@@ -106,6 +106,16 @@ class QiqBlockModelTest {
     }
 
     @Test
+    fun unclosedOpenerDoesNotSwallowLaterBlocks() {
+        // A half-typed `{{ if (` (no `}}`) must not consume the following block:
+        // the scanner skips it and still pairs the later setSection/endSection.
+        val text = "{{ if (\n{{ setSection('a') }}\nx\n{{ endSection() }}"
+        val blocks = ranges(text)
+        assertEquals(1, blocks.size)
+        assertEquals(QiqBlockType.SECTION, blocks[0].type)
+    }
+
+    @Test
     fun elseInsideIfIsNotABoundary() {
         val text = """
             {{ if (${'$'}x): }}

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModelTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModelTest.kt
@@ -141,6 +141,29 @@ class QiqBlockModelTest {
     }
 
     @Test
+    fun directiveHeadsMatchCaseInsensitively() {
+        // PHP keywords are case-insensitive; uppercase directives still pair.
+        val text = "{{ IF (${'$'}x): }}body{{ ENDIF }}"
+        val block = ranges(text).single()
+        assertEquals(QiqBlockType.IF, block.type)
+    }
+
+    @Test
+    fun openerWithoutParenthesesIsNotABlock() {
+        // All openers are call/condition forms; without '(' they are not blocks.
+        assertTrue(ranges("{{ if ${'$'}x: }}body{{ endif }}").isEmpty())
+        assertTrue(ranges("{{ setSection 'a' }}body{{ endSection() }}").isEmpty())
+    }
+
+    @Test
+    fun callStyleCloserMustBeEmptyArgCall() {
+        // Only an empty-arg call closes a section/block; arguments are invalid.
+        assertTrue(ranges("{{ setSection('a') }}x{{ endSection(${'$'}x) }}").isEmpty())
+        // Empty-arg call with a trailing semicolon is accepted.
+        assertEquals(1, ranges("{{ setSection('a') }}x{{ endSection(); }}").size)
+    }
+
+    @Test
     fun outputExpressionsAreNotBlocks() {
         val text = "{{= ${'$'}title }} {{h ${'$'}body }} {{ noop() }}"
         assertTrue(ranges(text).isEmpty())

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModelTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModelTest.kt
@@ -1,0 +1,137 @@
+package io.github.jingu.idea_qiq_plugin.block
+
+import com.intellij.openapi.util.TextRange
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class QiqBlockModelTest {
+
+    private fun ranges(text: String) = QiqBlockModel.computeBlockRanges(text)
+
+    /** Convenience: the opener/closer delimiter substrings of a matched block. */
+    private fun QiqBlockRange.openText(text: String) = text.substring(open.startOffset, open.endOffset)
+    private fun QiqBlockRange.closeText(text: String) = text.substring(close.startOffset, close.endOffset)
+
+    @Test
+    fun pairsIfWithEndif() {
+        val text = """
+            {{ if (${'$'}x): }}
+            <p>hi</p>
+            {{ endif }}
+        """.trimIndent()
+
+        val blocks = ranges(text)
+        assertEquals(1, blocks.size)
+        assertEquals(QiqBlockType.IF, blocks[0].type)
+        assertEquals("{{ if (${'$'}x): }}", blocks[0].openText(text))
+        assertEquals("{{ endif }}", blocks[0].closeText(text))
+    }
+
+    @Test
+    fun ignoresIfWithoutColon() {
+        // No alternative-syntax colon => not a block opener.
+        val text = "{{ if (${'$'}x) }}<p>hi</p>{{ endif }}"
+        assertTrue(ranges(text).isEmpty())
+    }
+
+    @Test
+    fun pairsForeachAndFor() {
+        val text = """
+            {{ foreach (${'$'}items as ${'$'}i): }}
+            {{ for (${'$'}n = 0; ${'$'}n < 3; ${'$'}n++): }}
+            x
+            {{ endfor }}
+            {{ endforeach }}
+        """.trimIndent()
+
+        val blocks = ranges(text)
+        assertEquals(2, blocks.size)
+        // sorted by opener offset: foreach first, then the inner for
+        assertEquals(QiqBlockType.FOREACH, blocks[0].type)
+        assertEquals(QiqBlockType.FOR, blocks[1].type)
+    }
+
+    @Test
+    fun pairsSectionAndBlockCalls() {
+        val text = """
+            {{ setSection('header') }}
+            <h1>title</h1>
+            {{ endSection() }}
+            {{ setBlock('body') }}
+            content
+            {{ endBlock() }}
+        """.trimIndent()
+
+        val blocks = ranges(text)
+        assertEquals(2, blocks.size)
+        assertEquals(QiqBlockType.SECTION, blocks[0].type)
+        assertEquals(QiqBlockType.BLOCK, blocks[1].type)
+    }
+
+    @Test
+    fun nestedSameTypeMatchesNearestPartner() {
+        val text = """
+            {{ if (${'$'}a): }}
+            {{ if (${'$'}b): }}
+            inner
+            {{ endif }}
+            {{ endif }}
+        """.trimIndent()
+
+        val blocks = ranges(text).sortedBy { it.open.startOffset }
+        assertEquals(2, blocks.size)
+
+        val outer = blocks[0]
+        val inner = blocks[1]
+        // The inner opener's closer is the FIRST endif; the outer's is the second.
+        assertTrue(inner.close.startOffset < outer.close.startOffset)
+        // Proper nesting: inner block is fully contained in the outer body.
+        assertTrue(outer.bodyRange.contains(inner.fullRange))
+    }
+
+    @Test
+    fun unclosedOpenerProducesNoRange() {
+        val text = """
+            {{ if (${'$'}x): }}
+            <p>no closer here</p>
+        """.trimIndent()
+        assertTrue(ranges(text).isEmpty())
+    }
+
+    @Test
+    fun unmatchedCloserProducesNoRange() {
+        val text = "<p>stray</p>\n{{ endif }}"
+        assertTrue(ranges(text).isEmpty())
+    }
+
+    @Test
+    fun elseInsideIfIsNotABoundary() {
+        val text = """
+            {{ if (${'$'}x): }}
+            a
+            {{ else: }}
+            b
+            {{ endif }}
+        """.trimIndent()
+
+        val blocks = ranges(text)
+        assertEquals(1, blocks.size)
+        // The single if/endif spans across the else branch.
+        val block = blocks[0]
+        assertTrue(block.bodyRange.contains(text.indexOf("{{ else: }}")))
+    }
+
+    @Test
+    fun outputExpressionsAreNotBlocks() {
+        val text = "{{= ${'$'}title }} {{h ${'$'}body }} {{ noop() }}"
+        assertTrue(ranges(text).isEmpty())
+    }
+
+    @Test
+    fun bodyRangeExcludesDelimiters() {
+        val text = "{{ if (${'$'}x): }}BODY{{ endif }}"
+        val block = ranges(text).single()
+        assertEquals(TextRange(text.indexOf("BODY"), text.indexOf("BODY") + "BODY".length), block.bodyRange)
+    }
+}

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModelTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModelTest.kt
@@ -123,6 +123,24 @@ class QiqBlockModelTest {
     }
 
     @Test
+    fun ternaryColonDoesNotMakeNonBlockIfABlock() {
+        // The colon belongs to the ternary, not to alternative syntax: not a block.
+        val withoutAltColon = "{{ if (${'$'}a ? ${'$'}b : ${'$'}c) }}x{{ endif }}"
+        assertTrue(ranges(withoutAltColon).isEmpty())
+
+        // The same condition WITH the trailing alternative-syntax colon is a block.
+        val withAltColon = "{{ if (${'$'}a ? ${'$'}b : ${'$'}c): }}x{{ endif }}"
+        assertEquals(1, ranges(withAltColon).size)
+    }
+
+    @Test
+    fun callStyleCloserWithoutParensIsNotACloser() {
+        // `{{ endSection }}` without parentheses is invalid; the section stays unclosed.
+        val text = "{{ setSection('a') }}x{{ endSection }}"
+        assertTrue(ranges(text).isEmpty())
+    }
+
+    @Test
     fun outputExpressionsAreNotBlocks() {
         val text = "{{= ${'$'}title }} {{h ${'$'}body }} {{ noop() }}"
         assertTrue(ranges(text).isEmpty())


### PR DESCRIPTION
## 概要
Epic #37 (1.0 roadmap) Tier 1 の最優先タスク **#27** を実装。Qiq ブロックディレクティブのコードフォールディングと、その基盤となる共有 block-range モデルを追加します。

ロードマップで「#27 (block-range model) は #28・#29・#30 の基盤」と位置づけられたとおり、再利用可能なペアリングモデルを切り出しています。

## 変更内容
### 1. 共有 block-range モデル — `block/QiqBlockModel.kt` (新規)
- `{{ if (...): }}` ↔ `{{ endif }}`、`foreach`/`for`/`setSection`/`setBlock` の opener/closer をペアリング
- レキサが `{{ ... }}` をインジェクションホストに平坦化し `if`/`endif` の区別がテキストにしか残らないため、PSI ではなくテキスト走査を採用(既存 `QiqEnterHandler` と同方針)
- スタックで入れ子を正しく対応付け、**未対応の opener/closer はペアにせず破棄**(壊れたフォールディング領域を作らない)
- `if`/`foreach`/`for` は alternative syntax のコロン終端時のみブロック扱い(誤爆防止)
- `QiqBlockType` / `QiqBlockRange` は #28 (block matching)・#29 (structure view)・#30 (unclosed-block inspection) でそのまま再利用できる設計

### 2. `editor/QiqFoldingBuilder.kt` (新規)
- 上記モデルを使い、ブロックの**ボディのみ**を畳む → 折りたたみ時は `{{ if (...): }}…{{ endif }}` と表示
- 単一行ブロックはスキップ、デフォルト展開
- `DumbAware`

### 3. `plugin.xml`
- `lang.foldingBuilder` (language=Qiq) を登録

## テスト
- `QiqBlockModelTest` (新規・純粋ロジック10ケース): ペアリング / 入れ子 / else 跨ぎ / 未対応 opener・closer / 出力式の除外 / bodyRange 境界
- 全テストスイート通過、回帰なし
- `buildPlugin` 成功、実機(PhpStorm)で動作確認済み

## Acceptance (#27)
- [x] 均衡したブロックが個別に畳める / 入れ子も独立
- [x] 不均衡なブロックは壊れた領域を作らない
- [x] block-range ペアリングロジックの回帰テスト(純粋)

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)