### PR TITLE
feat: block matching & brace highlighting for Qiq directives (#28)

### DIFF
--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModel.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModel.kt
@@ -98,13 +98,28 @@ object QiqBlockModel {
         return result
     }
 
+    /**
+     * The block whose opener or closer delimiter [offset] falls on, if any.
+     *
+     * A delimiter spans `{{ ... }}` inclusive of both ends, so a caret resting at
+     * either edge of an opener or closer still resolves to its block. Used to drive
+     * block-pair highlighting.
+     */
+    fun blockAtDelimiter(text: CharSequence, offset: Int): QiqBlockRange? =
+        computeBlockRanges(text).firstOrNull { block ->
+            offset in block.open.startOffset..block.open.endOffset ||
+                offset in block.close.startOffset..block.close.endOffset
+        }
+
     private fun accept(
         inner: String,
         delimiter: TextRange,
         openers: ArrayDeque<Pending>,
         result: MutableList<QiqBlockRange>,
     ) {
-        val head = inner.takeWhile { !it.isWhitespace() && it != '(' && it != ':' }
+        // Stop at '(' (call/condition), ':' (alt-syntax opener) or ';' so a
+        // semicolon-terminated closer such as `{{ endif; }}` still yields "endif".
+        val head = inner.takeWhile { !it.isWhitespace() && it != '(' && it != ':' && it != ';' }
 
         val openType = QiqBlockType.forOpenHead(head)
         // Every opener is a call/condition form whose '(' follows the head directly

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/editor/QiqBlockPairHighlightUsagesHandlerFactory.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/editor/QiqBlockPairHighlightUsagesHandlerFactory.kt
@@ -1,0 +1,56 @@
+package io.github.jingu.idea_qiq_plugin.editor
+
+import com.intellij.codeInsight.highlighting.HighlightUsagesHandlerBase
+import com.intellij.codeInsight.highlighting.HighlightUsagesHandlerFactoryBase
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.util.Consumer
+import io.github.jingu.idea_qiq_plugin.block.QiqBlockModel
+import io.github.jingu.idea_qiq_plugin.lang.QiqTemplateLanguage
+
+/**
+ * Highlights the matching Qiq block directive when the caret rests on either the
+ * opener or the closer — `{{ if (...): }}` ↔ `{{ endif }}`, and likewise for
+ * `foreach`, `for`, `setSection`, `setBlock`.
+ *
+ * Block pairs span several tokens and (for nested same-keyword blocks) cannot be
+ * matched by the token-level brace matcher, so they are resolved through the shared
+ * [QiqBlockModel] instead.
+ */
+class QiqBlockPairHighlightUsagesHandlerFactory : HighlightUsagesHandlerFactoryBase() {
+
+    override fun createHighlightUsagesHandler(
+        editor: Editor,
+        file: PsiFile,
+        target: PsiElement,
+    ): HighlightUsagesHandlerBase<PsiElement>? {
+        if (!file.viewProvider.languages.any { it.isKindOf(QiqTemplateLanguage) }) return null
+
+        val offset = editor.caretModel.offset
+        val block = QiqBlockModel.blockAtDelimiter(editor.document.charsSequence, offset) ?: return null
+
+        return Handler(editor, file, listOf(block.open, block.close))
+    }
+
+    private class Handler(
+        editor: Editor,
+        file: PsiFile,
+        private val ranges: List<TextRange>,
+    ) : HighlightUsagesHandlerBase<PsiElement>(editor, file) {
+
+        override fun getTargets(): List<PsiElement> = listOf(myFile)
+
+        override fun selectTargets(
+            targets: List<PsiElement>,
+            selectionConsumer: Consumer<in List<PsiElement>>,
+        ) {
+            selectionConsumer.consume(targets)
+        }
+
+        override fun computeUsages(targets: List<PsiElement>) {
+            ranges.forEach(myReadUsages::add)
+        }
+    }
+}

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/editor/QiqBraceMatcher.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/editor/QiqBraceMatcher.kt
@@ -1,0 +1,47 @@
+package io.github.jingu.idea_qiq_plugin.editor
+
+import com.intellij.codeInsight.highlighting.PairedBraceMatcherAdapter
+import com.intellij.lang.BracePair
+import com.intellij.lang.PairedBraceMatcher
+import com.intellij.psi.PsiFile
+import com.intellij.psi.tree.IElementType
+import io.github.jingu.idea_qiq_plugin.lang.QiqTemplateLanguage
+import io.github.jingu.idea_qiq_plugin.lang.QiqTokenTypes
+
+/**
+ * Matches Qiq delimiter pairs: `{{` and the escape variants `{{=`/`{{h`/`{{a`/
+ * `{{c`/`{{j`/`{{u` against their closing `}}`.
+ *
+ * Wrapped in [PairedBraceMatcherAdapter] (like the bundled Blade support) so the
+ * matcher stays scoped to the Qiq layer of the template file and does not pair a
+ * Qiq delimiter with a brace from the injected PHP or surrounding HTML.
+ */
+class QiqBraceMatcher : PairedBraceMatcherAdapter(Matcher, QiqTemplateLanguage) {
+
+    private object Matcher : PairedBraceMatcher {
+        override fun getPairs(): Array<BracePair> = PAIRS
+
+        override fun isPairedBracesAllowedBeforeType(
+            lbraceType: IElementType,
+            contextType: IElementType?,
+        ): Boolean = true
+
+        override fun getCodeConstructStart(file: PsiFile?, openingBraceOffset: Int): Int =
+            openingBraceOffset
+    }
+
+    companion object {
+        // Left tokens are what the lexer emits in YYINITIAL; right tokens are what
+        // each Qiq sub-state emits for the closing `}}`. `{{a` and `{{c` share the
+        // QIQ_ESC state, so both close with RBRACEC.
+        private val PAIRS = arrayOf(
+            BracePair(QiqTokenTypes.CODE_OPEN, QiqTokenTypes.RBRACE2, true),
+            BracePair(QiqTokenTypes.RAW_OPEN, QiqTokenTypes.RBRACE_EQ, true),
+            BracePair(QiqTokenTypes.ESCAPE_H_OPEN, QiqTokenTypes.RBRACEH, true),
+            BracePair(QiqTokenTypes.ESCAPE_J_OPEN, QiqTokenTypes.RBRACEJ, true),
+            BracePair(QiqTokenTypes.ESCAPE_U_OPEN, QiqTokenTypes.RBRACEU, true),
+            BracePair(QiqTokenTypes.ESCAPE_A_OPEN, QiqTokenTypes.RBRACEC, true),
+            BracePair(QiqTokenTypes.ESCAPE_C_OPEN, QiqTokenTypes.RBRACEC, true),
+        )
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -53,6 +53,20 @@
                 language="Qiq"
                 implementationClass="io.github.jingu.idea_qiq_plugin.editor.QiqFoldingBuilder"/>
 
+        <!-- Brace matching for Qiq delimiters: {{ / {{= / {{h / {{a / {{c /
+             {{j / {{u against the closing }}. Scoped to the Qiq layer so a
+             delimiter never pairs with a brace from injected PHP or HTML. -->
+        <lang.braceMatcher
+                language="Qiq"
+                implementationClass="io.github.jingu.idea_qiq_plugin.editor.QiqBraceMatcher"/>
+
+        <!-- Block-pair highlighting: caret on {{ if }}/{{ endif }} (and
+             foreach/for/setSection/setBlock) highlights its partner. Uses the
+             shared block-range model so nested same-keyword blocks match the
+             correct partner. -->
+        <highlightUsagesHandlerFactory
+                implementation="io.github.jingu.idea_qiq_plugin.editor.QiqBlockPairHighlightUsagesHandlerFactory"/>
+
         <!-- Color Settings Page -->
         <colorSettingsPage implementation="io.github.jingu.idea_qiq_plugin.ui.QiqColorSettingsPage"/>
 

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModelTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModelTest.kt
@@ -181,9 +181,60 @@ class QiqBlockModelTest {
     }
 
     @Test
+    fun pairsSemicolonTerminatedClosers() {
+        // `{{ endif; }}` is syntactically allowed; the trailing semicolon must
+        // not prevent the closer from being recognised.
+        val text = """
+            {{ if (${'$'}x): }}body{{ endif; }}
+            {{ foreach (${'$'}xs as ${'$'}x): }}b{{ endforeach; }}
+            {{ for (${'$'}i = 0; ${'$'}i < 3; ${'$'}i++): }}c{{ endfor; }}
+        """.trimIndent()
+
+        val blocks = ranges(text)
+        assertEquals(3, blocks.size)
+        assertEquals(setOf(QiqBlockType.IF, QiqBlockType.FOREACH, QiqBlockType.FOR), blocks.map { it.type }.toSet())
+    }
+
+    @Test
     fun outputExpressionsAreNotBlocks() {
         val text = "{{= ${'$'}title }} {{h ${'$'}body }} {{ noop() }}"
         assertTrue(ranges(text).isEmpty())
+    }
+
+    @Test
+    fun blockAtDelimiterResolvesFromOpenerAndCloser() {
+        val text = """
+            {{ if (${'$'}x): }}
+            body
+            {{ endif }}
+        """.trimIndent()
+
+        val onOpener = QiqBlockModel.blockAtDelimiter(text, text.indexOf("if"))
+        val onCloser = QiqBlockModel.blockAtDelimiter(text, text.indexOf("endif"))
+        val inBody = QiqBlockModel.blockAtDelimiter(text, text.indexOf("body"))
+
+        assertEquals(QiqBlockType.IF, onOpener?.type)
+        // Caret on either delimiter resolves to the same block.
+        assertEquals(onOpener, onCloser)
+        assertEquals(null, inBody)
+    }
+
+    @Test
+    fun blockAtDelimiterPicksInnerNestedBlock() {
+        val text = """
+            {{ if (${'$'}a): }}
+            {{ if (${'$'}b): }}
+            inner
+            {{ endif }}
+            {{ endif }}
+        """.trimIndent()
+
+        // The first endif closes the inner block.
+        val firstEndif = text.indexOf("{{ endif }}")
+        val block = QiqBlockModel.blockAtDelimiter(text, firstEndif + 3)
+
+        // Its opener is the SECOND `if (` (the inner one), not the outer.
+        assertEquals(text.indexOf("if (${'$'}b)") - 3, block?.open?.startOffset)
     }
 
     @Test


### PR DESCRIPTION
## 概要
Epic #37 (1.0 roadmap) Tier 1 の **#28** を実装。Qiq デリミタの brace matching と、ブロックディレクティブのペアハイライトを追加します。

> **Note**: #27 (PR #38) の上にスタックした PR です。base は `feat/block-range-folding`。#27 マージ後に base を `develop` に切り替え可能です。`QiqBlockModel` (#27) を再利用します。

## 変更内容
### 1. `editor/QiqBraceMatcher.kt` (新規) — デリミタの brace matching
- `{{` / `{{=` / `{{h` / `{{a` / `{{c` / `{{j` / `{{u` ↔ `}}` をペアリング
- Blade 同様 `PairedBraceMatcherAdapter` でラップし Qiq レイヤーに限定(注入 PHP / HTML のブレースと誤マッチしない)
- `{{a` と `{{c` はレキサ上同一 `QIQ_ESC` 状態で `}}` を `RBRACEC` として返すため両方を `RBRACEC` にマップ

### 2. `editor/QiqBlockPairHighlightUsagesHandlerFactory.kt` (新規) — ブロックペアのハイライト
- キャレットを `{{ if (...): }}` / `{{ endif }}`(および `foreach`/`for`/`setSection`/`setBlock`)に置くと相方をハイライト
- 複数トークンに跨り、入れ子の同種ブロックはトークンレベル brace matcher では不可能なため `QiqBlockModel.blockAtDelimiter()` で解決

### 3. `block/QiqBlockModel.kt` — 共有モデルの拡張 + バグ修正
- `blockAtDelimiter(text, offset)` を追加(キャレット位置のブロック解決)
- head 抽出を `;` でも停止するよう修正 → 構文上許容される `{{ endif; }}` 等のセミコロン終端 closer を正しく認識(実機検証で発見)

### 4. `plugin.xml`
- `lang.braceMatcher` / `highlightUsagesHandlerFactory` を登録

## テスト
- `QiqBlockModelTest` に4ケース追加 → 計13ケース全通過(opener/closer 双方から解決・入れ子で正しい相方・セミコロン終端 closer)
- 全テスト通過、`buildPlugin` 成功、実機(PhpStorm)で動作確認済み

## Acceptance (#28)
- [x] caret on an opener highlights its closer and vice versa
- [x] nested same-type blocks match the correct partner

## 既知のフォローアップ
`QiqEnterHandler` に同一の head 抽出ロジックが複製されており、同じセミコロン終端バグを抱えています。別タスク(EnterHandler を QiqBlockModel へ統合)で一元化予定です。

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)