### PR TITLE
feat: structure view (outline) for Qiq sections and blocks (#29)

### DIFF
--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModel.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModel.kt
@@ -71,6 +71,25 @@ object QiqBlockModel {
         val openers = ArrayDeque<Pending>()
         val result = ArrayList<QiqBlockRange>()
 
+        for (directive in scanDirectives(text)) {
+            accept(directive, openers, result)
+        }
+
+        result.sortBy { it.open.startOffset }
+        return result
+    }
+
+    /** A single `{{ ... }}` directive: its delimiter span, [head] keyword and trimmed [inner] text. */
+    internal data class Directive(val range: TextRange, val head: String, val inner: String)
+
+    /**
+     * Every `{{ ... }}` directive in [text], in document order.
+     *
+     * Shared by [computeBlockRanges] and the structure view so the delimiter scan
+     * and head extraction live in one place.
+     */
+    internal fun scanDirectives(text: CharSequence): List<Directive> {
+        val directives = ArrayList<Directive>()
         var i = 0
         val n = text.length
         while (i < n - 1) {
@@ -84,18 +103,18 @@ object QiqBlockModel {
                     i = nextOpen
                     continue
                 }
-                val openStart = i
                 val openEnd = closeStart + 2
                 val inner = text.subSequence(i + 2, closeStart).toString().trim()
-                accept(inner, TextRange(openStart, openEnd), openers, result)
+                // Stop at '(' (call/condition), ':' (alt-syntax opener) or ';' so a
+                // semicolon-terminated closer such as `{{ endif; }}` still yields "endif".
+                val head = inner.takeWhile { !it.isWhitespace() && it != '(' && it != ':' && it != ';' }
+                directives.add(Directive(TextRange(i, openEnd), head, inner))
                 i = openEnd
             } else {
                 i++
             }
         }
-
-        result.sortBy { it.open.startOffset }
-        return result
+        return directives
     }
 
     /**
@@ -112,16 +131,11 @@ object QiqBlockModel {
         }
 
     private fun accept(
-        inner: String,
-        delimiter: TextRange,
+        directive: Directive,
         openers: ArrayDeque<Pending>,
         result: MutableList<QiqBlockRange>,
     ) {
-        // Stop at '(' (call/condition), ':' (alt-syntax opener) or ';' so a
-        // semicolon-terminated closer such as `{{ endif; }}` still yields "endif".
-        val head = inner.takeWhile { !it.isWhitespace() && it != '(' && it != ':' && it != ';' }
-
-        val openType = QiqBlockType.forOpenHead(head)
+        val openType = QiqBlockType.forOpenHead(directive.head)
         // Every opener is a call/condition form whose '(' follows the head directly
         // (whitespace allowed). Requiring the '(' right after the head rejects bare
         // `{{ if $x: }}` / `{{ setSection 'a' }}` and avoids a false positive when an
@@ -129,19 +143,19 @@ object QiqBlockModel {
         // additionally require the trailing alternative-syntax colon; testing the
         // trailing colon (not any colon) keeps a ternary `?:` from being mistaken for one.
         if (openType != null &&
-            inner.substring(head.length).trimStart().startsWith("(") &&
-            (!openType.requiresColon || inner.trimEnd().endsWith(':'))
+            directive.inner.substring(directive.head.length).trimStart().startsWith("(") &&
+            (!openType.requiresColon || directive.inner.trimEnd().endsWith(':'))
         ) {
-            openers.addLast(Pending(openType, delimiter))
+            openers.addLast(Pending(openType, directive.range))
             return
         }
 
-        val closeType = QiqBlockType.forCloseHead(head) ?: return
+        val closeType = QiqBlockType.forCloseHead(directive.head) ?: return
         // setSection/setBlock are call-style: only an empty-arg call closes them
         // (`{{ endSection() }}`, optional trailing `;`). Anything else — no parens,
         // or arguments — is invalid and must not pair.
         if ((closeType == QiqBlockType.SECTION || closeType == QiqBlockType.BLOCK) &&
-            !isEmptyArgClose(inner, closeType)
+            !isEmptyArgClose(directive.inner, closeType)
         ) {
             return
         }
@@ -151,7 +165,7 @@ object QiqBlockModel {
         val opener = openers[matchIndex]
         // Drop the matched opener and any inner blocks left unclosed above it.
         while (openers.size > matchIndex) openers.removeLast()
-        result.add(QiqBlockRange(closeType, opener.delimiter, delimiter))
+        result.add(QiqBlockRange(closeType, opener.delimiter, directive.range))
     }
 
     /** True if [inner] is an empty-arg call closer, e.g. `endSection()` / `endBlock() ;`. */

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/structure/QiqOutline.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/structure/QiqOutline.kt
@@ -1,0 +1,108 @@
+package io.github.jingu.idea_qiq_plugin.structure
+
+import com.intellij.openapi.util.TextRange
+import io.github.jingu.idea_qiq_plugin.block.QiqBlockModel
+import io.github.jingu.idea_qiq_plugin.block.QiqBlockType
+
+/** The kind of outline node, used to pick a structure-view icon. */
+enum class QiqOutlineKind { DIRECTIVE, SECTION, BLOCK, CONTROL }
+
+/**
+ * One node in the Qiq structure outline.
+ *
+ * [offset] is where clicking the node navigates to (the `{{` of the directive).
+ */
+data class QiqOutlineNode(
+    val label: String,
+    val kind: QiqOutlineKind,
+    val offset: Int,
+    val children: List<QiqOutlineNode>,
+)
+
+/**
+ * Builds the structure-view outline from raw template text.
+ *
+ * The outline nests `setSection`/`setBlock` and the control blocks `if`/`foreach`/
+ * `for` using the shared [QiqBlockModel] pairing, and surfaces top-level
+ * `setLayout(...)` / `extends(...)` directives. Pure and text-based so it can be
+ * unit-tested without the platform.
+ */
+object QiqOutline {
+
+    private val TOP_LEVEL_HEADS = setOf("setLayout", "extends")
+    private val WHITESPACE_RUN = Regex("\\s+")
+
+    fun build(text: CharSequence): List<QiqOutlineNode> {
+        val directives = QiqBlockModel.scanDirectives(text)
+        val innerByStart = directives.associate { it.range.startOffset to it.inner }
+
+        // Containers: balanced block pairs, spanning opener-start .. closer-end.
+        val containers = QiqBlockModel.computeBlockRanges(text).map { block ->
+            Entry(
+                range = block.fullRange,
+                node = MutableNode(
+                    label(block.type, normalize(innerByStart[block.open.startOffset] ?: "")),
+                    kindOf(block.type),
+                    block.open.startOffset,
+                ),
+                isContainer = true,
+            )
+        }
+
+        // Leaves: standalone setLayout()/extends() directives.
+        val leaves = directives
+            .filter { it.head in TOP_LEVEL_HEADS }
+            .map { Entry(it.range, MutableNode(normalize(it.inner), QiqOutlineKind.DIRECTIVE, it.range.startOffset), isContainer = false) }
+
+        return assemble(containers + leaves)
+    }
+
+    /** Nest entries by range containment into a forest, preserving document order. */
+    private fun assemble(entries: List<Entry>): List<QiqOutlineNode> {
+        val sorted = entries.sortedWith(compareBy({ it.range.startOffset }, { -it.range.endOffset }))
+        val roots = ArrayList<MutableNode>()
+        val stack = ArrayDeque<Entry>()
+
+        for (entry in sorted) {
+            while (stack.isNotEmpty() && !stack.last().range.contains(entry.range)) {
+                stack.removeLast()
+            }
+            if (stack.isEmpty()) roots.add(entry.node) else stack.last().node.children.add(entry.node)
+            if (entry.isContainer) stack.addLast(entry)
+        }
+
+        return roots.map { it.toImmutable() }
+    }
+
+    private fun kindOf(type: QiqBlockType): QiqOutlineKind = when (type) {
+        QiqBlockType.SECTION -> QiqOutlineKind.SECTION
+        QiqBlockType.BLOCK -> QiqOutlineKind.BLOCK
+        QiqBlockType.IF, QiqBlockType.FOREACH, QiqBlockType.FOR -> QiqOutlineKind.CONTROL
+    }
+
+    private fun label(type: QiqBlockType, inner: String): String = when (type) {
+        QiqBlockType.SECTION -> "section " + (firstStringArg(inner) ?: inner)
+        QiqBlockType.BLOCK -> "block " + (firstStringArg(inner) ?: inner)
+        QiqBlockType.IF, QiqBlockType.FOREACH, QiqBlockType.FOR -> inner.trimEnd(';', ':', ' ')
+    }
+
+    /** Collapse internal newlines/tabs/runs of spaces so a multi-line directive renders on one line. */
+    private fun normalize(inner: String): String = inner.replace(WHITESPACE_RUN, " ").trim()
+
+    /** The first single- or double-quoted argument, e.g. `setSection('header')` -> `'header'`. */
+    private fun firstStringArg(inner: String): String? {
+        val open = inner.indexOfFirst { it == '\'' || it == '"' }
+        if (open < 0) return null
+        val quote = inner[open]
+        val close = inner.indexOf(quote, open + 1)
+        if (close < 0) return null
+        return inner.substring(open, close + 1)
+    }
+
+    private class Entry(val range: TextRange, val node: MutableNode, val isContainer: Boolean)
+
+    private class MutableNode(val label: String, val kind: QiqOutlineKind, val offset: Int) {
+        val children = ArrayList<MutableNode>()
+        fun toImmutable(): QiqOutlineNode = QiqOutlineNode(label, kind, offset, children.map { it.toImmutable() })
+    }
+}

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/structure/QiqStructureViewFactory.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/structure/QiqStructureViewFactory.kt
@@ -1,0 +1,85 @@
+package io.github.jingu.idea_qiq_plugin.structure
+
+import com.intellij.ide.projectView.PresentationData
+import com.intellij.ide.structureView.StructureViewBuilder
+import com.intellij.ide.structureView.StructureViewModel
+import com.intellij.ide.structureView.StructureViewModel.ElementInfoProvider
+import com.intellij.ide.structureView.StructureViewTreeElement
+import com.intellij.ide.structureView.TextEditorBasedStructureViewModel
+import com.intellij.ide.structureView.TreeBasedStructureViewBuilder
+import com.intellij.ide.util.treeView.smartTree.TreeElement
+import com.intellij.icons.AllIcons
+import com.intellij.lang.PsiStructureViewFactory
+import com.intellij.navigation.ItemPresentation
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
+import com.intellij.psi.PsiFile
+import io.github.jingu.idea_qiq_plugin.ui.QiqIcons
+import javax.swing.Icon
+
+/** Structure tool-window outline for Qiq templates (sections, blocks, control blocks). */
+class QiqStructureViewFactory : PsiStructureViewFactory {
+
+    override fun getStructureViewBuilder(psiFile: PsiFile): StructureViewBuilder =
+        object : TreeBasedStructureViewBuilder() {
+            override fun createStructureViewModel(editor: Editor?): StructureViewModel =
+                QiqStructureViewModel(psiFile, editor)
+
+            override fun isRootNodeShown(): Boolean = true
+        }
+}
+
+private class QiqStructureViewModel(psiFile: PsiFile, editor: Editor?) :
+    TextEditorBasedStructureViewModel(editor, psiFile), ElementInfoProvider {
+
+    private val root = QiqStructureViewElement(psiFile, null)
+
+    override fun getRoot(): StructureViewTreeElement = root
+
+    override fun isAlwaysShowsPlus(element: StructureViewTreeElement?): Boolean = false
+
+    override fun isAlwaysLeaf(element: StructureViewTreeElement?): Boolean =
+        (element?.value as? QiqOutlineNode)?.children?.isEmpty() ?: false
+}
+
+/**
+ * A structure node. [node] is null for the root (the file itself); otherwise it wraps
+ * a [QiqOutlineNode] and navigates to that directive's offset on click.
+ */
+private class QiqStructureViewElement(
+    private val file: PsiFile,
+    private val node: QiqOutlineNode?,
+) : StructureViewTreeElement {
+
+    override fun getValue(): Any = node ?: file
+
+    override fun getPresentation(): ItemPresentation =
+        if (node == null) PresentationData(file.name, null, QiqIcons.FILE, null)
+        else PresentationData(node.label, null, iconFor(node.kind), null)
+
+    override fun getChildren(): Array<TreeElement> {
+        val children = node?.children ?: QiqOutline.build(file.text)
+        return children.map { QiqStructureViewElement(file, it) }.toTypedArray()
+    }
+
+    override fun navigate(requestFocus: Boolean) {
+        val offset = node?.offset ?: return
+        val virtualFile = file.virtualFile ?: return
+        OpenFileDescriptor(file.project, virtualFile, offset).navigate(requestFocus)
+    }
+
+    override fun canNavigate(): Boolean = node != null && file.virtualFile != null
+
+    override fun canNavigateToSource(): Boolean = canNavigate()
+
+    private companion object {
+        // No dedicated branch/loop icons exist in AllIcons, so control blocks
+        // share one icon; the four categories stay visually distinct.
+        fun iconFor(kind: QiqOutlineKind): Icon = when (kind) {
+            QiqOutlineKind.DIRECTIVE -> AllIcons.Nodes.Include
+            QiqOutlineKind.SECTION -> AllIcons.Nodes.Field
+            QiqOutlineKind.BLOCK -> AllIcons.Nodes.Property
+            QiqOutlineKind.CONTROL -> AllIcons.Nodes.Lambda
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -67,6 +67,13 @@
         <highlightUsagesHandlerFactory
                 implementation="io.github.jingu.idea_qiq_plugin.editor.QiqBlockPairHighlightUsagesHandlerFactory"/>
 
+        <!-- Structure tool-window outline: sections/blocks and control blocks
+             (if/foreach/for) nested via the shared block-range model, plus
+             top-level setLayout()/extends() directives. -->
+        <lang.psiStructureViewFactory
+                language="Qiq"
+                implementationClass="io.github.jingu.idea_qiq_plugin.structure.QiqStructureViewFactory"/>
+
         <!-- Color Settings Page -->
         <colorSettingsPage implementation="io.github.jingu.idea_qiq_plugin.ui.QiqColorSettingsPage"/>
 

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/structure/QiqOutlineTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/structure/QiqOutlineTest.kt
@@ -1,0 +1,93 @@
+package io.github.jingu.idea_qiq_plugin.structure
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class QiqOutlineTest {
+
+    private fun build(text: String) = QiqOutline.build(text)
+
+    @Test
+    fun nestsBlocksAndLabelsSectionsByName() {
+        val text = """
+            {{ setLayout('layout/base') }}
+            {{ setSection('content') }}
+            {{ if (${'$'}x): }}
+            <p>hi</p>
+            {{ endif }}
+            {{ endSection() }}
+        """.trimIndent()
+
+        val roots = build(text)
+        // Top level: setLayout directive, then the section.
+        assertEquals(2, roots.size)
+        assertEquals("setLayout('layout/base')", roots[0].label)
+        assertEquals("section 'content'", roots[1].label)
+
+        // The section contains the if-block.
+        val ifNode = roots[1].children.single()
+        assertEquals("if (${'$'}x)", ifNode.label)
+        assertTrue(ifNode.children.isEmpty())
+
+        // Kinds drive the structure-view icons.
+        assertEquals(QiqOutlineKind.DIRECTIVE, roots[0].kind)
+        assertEquals(QiqOutlineKind.SECTION, roots[1].kind)
+        assertEquals(QiqOutlineKind.CONTROL, ifNode.kind)
+    }
+
+    @Test
+    fun navigationOffsetPointsAtOpeningDelimiter() {
+        val text = "{{ setSection('a') }}x{{ endSection() }}"
+        val section = build(text).single()
+        assertEquals(text.indexOf("{{ setSection"), section.offset)
+    }
+
+    @Test
+    fun nestedSameKeywordBlocksNestCorrectly() {
+        val text = """
+            {{ if (${'$'}a): }}
+            {{ if (${'$'}b): }}
+            inner
+            {{ endif }}
+            {{ endif }}
+        """.trimIndent()
+
+        val outer = build(text).single()
+        assertEquals("if (${'$'}a)", outer.label)
+        val inner = outer.children.single()
+        assertEquals("if (${'$'}b)", inner.label)
+    }
+
+    @Test
+    fun stripsTrailingSemicolonFromControlLabel() {
+        val text = "{{ if (${'$'}x): }}c{{ endif; }}"
+        val node = build(text).single()
+        assertEquals("if (${'$'}x)", node.label)
+    }
+
+    @Test
+    fun collapsesMultilineDirectiveLabelToOneLine() {
+        // A directive whose arguments span several lines/tabs must render on one line.
+        val text = "{{ foreach (${'$'}x->gen(\n\t${'$'}a,\n\t${'$'}b) as ${'$'}i): }}body{{ endforeach }}"
+        val node = build(text).single()
+        assertEquals("foreach (${'$'}x->gen( ${'$'}a, ${'$'}b) as ${'$'}i)", node.label)
+    }
+
+    @Test
+    fun extendsIsTopLevel() {
+        val text = "{{ extends('layout/main') }}\n<p>body</p>"
+        val roots = build(text)
+        assertEquals(1, roots.size)
+        assertEquals("extends('layout/main')", roots[0].label)
+    }
+
+    @Test
+    fun unbalancedBlockIsNotShownAsContainer() {
+        // No closer => not a balanced block, so it is not an outline container.
+        val text = "{{ setLayout('base') }}\n{{ if (${'$'}x): }}\n<p>no end</p>"
+        val roots = build(text)
+        assertEquals(1, roots.size)
+        assertEquals("setLayout('base')", roots[0].label)
+    }
+}


### PR DESCRIPTION
## 概要
Epic #37 (1.0 roadmap) Tier 1 の **#29** を実装。Qiq テンプレートの構造ツールウィンドウ(アウトライン)を追加します。

> **Note**: #28 (PR #39) の上にスタックした PR です。base は `feat/block-matching`。マージ順 #27→#28→#29 を想定。`QiqBlockModel` (#27) を再利用します。

## 変更内容
### 1. `structure/QiqOutline.kt` (新規・純粋ロジック)
- `QiqBlockModel` のブロックペアを**包含関係でネスト化**してアウトラインツリーを構築
- `setSection`/`setBlock` は名前引数でラベル(`section 'content'`)、`if`/`foreach`/`for` はディレクティブ要約(末尾 `;`/`:` 除去)
- `setLayout(...)` / `extends(...)` をトップレベルに表示
- **複数行ディレクティブのラベルを1行に正規化**(改行/タブ/連続スペース → 単一スペース)
- 各ノードに `QiqOutlineKind`(DIRECTIVE/SECTION/BLOCK/CONTROL)を付与

### 2. `structure/QiqStructureViewFactory.kt` (新規)
- `PsiStructureViewFactory` → `TreeBasedStructureViewBuilder` → `TextEditorBasedStructureViewModel`
- フラット PSI のためモデル駆動でツリー構築。クリックで該当ディレクティブの `{{` へナビゲート
- `kind` ごとに structure-view アイコンを割当(Include / Field / Property / Lambda)。分岐/ループ専用アイコンが AllIcons に無いため control は1アイコンに統合

### 3. `block/QiqBlockModel.kt`
- `{{ ... }}` 走査を `scanDirectives()` に抽出し `computeBlockRanges` と共有(head 抽出の一元化)。**回帰なし(13件維持)**

### 4. `plugin.xml`
- `lang.psiStructureViewFactory` を登録

## テスト
- `QiqOutlineTest` 7ケース(ネスト・名前ラベル・ナビ offset・同種ネスト・セミコロン除去・未均衡ブロック非表示・複数行ラベル正規化・kind)
- 全テスト通過、`buildPlugin` 成功、実機(PhpStorm)で動作・アイコン確認済み

## Acceptance (#29)
- [x] Outline reflects nesting and updates as the file changes
- [x] Section/block nodes labelled by their name argument; clicking navigates
- [x] Uses the shared block-range model

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)