### PR TITLE
refactor: unify QiqEnterHandler block detection onto QiqBlockModel (#42)

### DIFF
--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModel.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModel.kt
@@ -128,10 +128,7 @@ object QiqBlockModel {
                 }
                 val openEnd = closeStart + 2
                 val inner = text.subSequence(i + 2, closeStart).toString().trim()
-                // Stop at '(' (call/condition), ':' (alt-syntax opener) or ';' so a
-                // semicolon-terminated closer such as `{{ endif; }}` still yields "endif".
-                val head = inner.takeWhile { !it.isWhitespace() && it != '(' && it != ':' && it != ';' }
-                directives.add(Directive(TextRange(i, openEnd), head, inner))
+                directives.add(Directive(TextRange(i, openEnd), headOf(inner), inner))
                 i = openEnd
             } else {
                 i++
@@ -163,7 +160,7 @@ object QiqBlockModel {
         val problems = ArrayList<QiqBlockProblem>()
 
         for (directive in scanDirectives(text)) {
-            val openType = openTypeOf(directive)
+            val openType = openerTypeOf(directive.inner)
             if (openType != null) {
                 openers.addLast(Pending(openType, directive.range))
                 continue
@@ -212,7 +209,7 @@ object QiqBlockModel {
         openers: ArrayDeque<Pending>,
         result: MutableList<QiqBlockRange>,
     ) {
-        val openType = openTypeOf(directive)
+        val openType = openerTypeOf(directive.inner)
         if (openType != null) {
             openers.addLast(Pending(openType, directive.range))
             return
@@ -229,18 +226,26 @@ object QiqBlockModel {
     }
 
     /**
-     * The block type this directive opens, or null. Every opener is a call/condition
-     * form whose '(' follows the head directly (whitespace allowed); requiring it there
-     * rejects bare `{{ if $x: }}` / `{{ setSection 'a' }}` and avoids a false positive
-     * when an inner call supplies the '(' (e.g. `{{ if $x && foo(): }}`). if/foreach/for
-     * additionally require the trailing alternative-syntax colon; testing the trailing
-     * colon (not any colon) keeps a ternary `?:` from being mistaken for one.
+     * The block type an opener `{{ ... }}` whose content is [inner] opens, or null if
+     * [inner] is not a block opener.
+     *
+     * Every opener is a call/condition form whose '(' follows the head directly
+     * (whitespace allowed); requiring it there rejects bare `{{ if $x: }}` /
+     * `{{ setSection 'a' }}` and avoids a false positive when an inner call supplies the
+     * '(' (e.g. `{{ if $x && foo(): }}`). if/foreach/for additionally require the
+     * trailing alternative-syntax colon; testing the trailing colon (not any colon)
+     * keeps a ternary `?:` from being mistaken for one.
+     *
+     * The single source of truth for "is this a block opener", shared by the block
+     * pairing here and [io.github.jingu.idea_qiq_plugin.editor.QiqEnterHandler].
      */
-    private fun openTypeOf(directive: Directive): QiqBlockType? =
-        QiqBlockType.forOpenHead(directive.head)?.takeIf {
-            directive.inner.substring(directive.head.length).trimStart().startsWith("(") &&
-                (!it.requiresColon || directive.inner.trimEnd().endsWith(':'))
+    fun openerTypeOf(inner: String): QiqBlockType? {
+        val head = headOf(inner)
+        return QiqBlockType.forOpenHead(head)?.takeIf {
+            inner.substring(head.length).trimStart().startsWith("(") &&
+                (!it.requiresColon || inner.trimEnd().endsWith(':'))
         }
+    }
 
     /**
      * The block type this directive closes, or null. `setSection`/`setBlock` are
@@ -258,6 +263,14 @@ object QiqBlockModel {
     /** True if [inner] is an empty-arg call closer, e.g. `endSection()` / `endBlock() ;`. */
     private fun isEmptyArgClose(inner: String, type: QiqBlockType): Boolean =
         Regex("""(?i)${Regex.escape(type.closeHead)}\s*\(\s*\)\s*;?""").matches(inner)
+
+    /**
+     * The leading keyword of a directive's [inner] text. Stops at '(' (call/condition),
+     * ':' (alt-syntax opener) or ';' so a semicolon-terminated closer such as
+     * `{{ endif; }}` still yields "endif".
+     */
+    private fun headOf(inner: String): String =
+        inner.takeWhile { !it.isWhitespace() && it != '(' && it != ':' && it != ';' }
 
     private fun indexOfDoubleBrace(text: CharSequence, from: Int): Int? {
         var j = from

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/editor/QiqEnterHandler.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/editor/QiqEnterHandler.kt
@@ -6,8 +6,8 @@ import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiFile
+import io.github.jingu.idea_qiq_plugin.block.QiqBlockModel
 import io.github.jingu.idea_qiq_plugin.lang.QiqTemplateLanguage
-import kotlin.text.RegexOption
 
 class QiqEnterHandler : EnterHandlerDelegateAdapter() {
 
@@ -49,21 +49,14 @@ class QiqEnterHandler : EnterHandlerDelegateAdapter() {
         // 対応する "{{" を左へスキャン
         val openPos = findLastOpenDoubleBrace(text, closeAfter - 2) ?: return Result.Continue
 
-        // 中身を取り出し、先頭トークンを抽出
+        // 中身を取り出し、ブロック opener か判定（ブロックセット・コロンルールは
+        // QiqBlockModel に一元化）
         val inside = text.subSequence(openPos + 2, closeAfter - 2).toString().trim()
-        val head = inside.takeWhile { !it.isWhitespace() && it != '(' && it != ':' }
+        val blockType = QiqBlockModel.openerTypeOf(inside) ?: return Result.Continue
+        val closer = blockType.closeText
 
-        val closer = when {
-            head in blockClosers -> blockClosers.getValue(head)
-            else -> return Result.Continue
-        }
-
-        // if/foreach/for はコロン終端のものだけをブロック扱い（誤爆防止）
-        if (head in listOf("if", "foreach", "for") && !inside.contains(':')) {
-            return Result.Continue
-        }
-
-        if (hasMatchingCloser(text, closeAfter, head, closer)) {
+        // この opener が文書全体で既に閉じられているなら挿入しない
+        if (isOpenerClosed(text, openPos)) {
             return Result.Continue
         }
 
@@ -99,69 +92,13 @@ class QiqEnterHandler : EnterHandlerDelegateAdapter() {
         return null
     }
 
-    internal fun hasMatchingCloser(
-        text: CharSequence,
-        searchStart: Int,
-        head: String,
-        closer: String
-    ): Boolean {
-        val openRegex = openPatterns.getValue(head)
-        val closeRegex = closePatterns.getValue(head)
-
-        var index = searchStart
-        var depth = 0
-
-        while (index < text.length) {
-            val closeMatch = closeRegex.find(text, index)
-            val openMatch = openRegex.find(text, index)
-
-            val next = when {
-                closeMatch == null && openMatch == null -> return false
-                closeMatch != null && (openMatch == null || closeMatch.range.first < openMatch.range.first) -> {
-                    MatchResultWrapper(closeMatch, isClose = true)
-                }
-                else -> MatchResultWrapper(openMatch!!, isClose = false)
-            }
-
-            if (next.isClose) {
-                if (depth == 0) {
-                    return true
-                }
-                depth--
-            } else {
-                depth++
-            }
-            index = next.match.range.last + 1
-        }
-
-        return false
-    }
-
-    internal data class MatchResultWrapper(val match: MatchResult, val isClose: Boolean)
-
-    companion object {
-        internal val blockClosers = mapOf(
-            "setSection" to "endSection()",
-            "setBlock"   to "endBlock()",
-            "if"         to "endif",
-            "foreach"    to "endforeach",
-            "for"        to "endfor",
-        )
-
-        internal val openPatterns: Map<String, Regex> = blockClosers.keys.associateWith { head ->
-            Regex("""\{\{\s*${Regex.escape(head)}\b""", RegexOption.IGNORE_CASE)
-        }
-
-        internal val closePatterns: Map<String, Regex> = blockClosers.mapValues { (_, closer) ->
-            val pattern = if (closer.endsWith("()")) {
-                val name = closer.dropLast(2)
-                """\{\{\s*${Regex.escape(name)}\s*\(\s*\)\s*}}"""
-            } else {
-                """\{\{\s*${Regex.escape(closer)}\b[^}]*}}"""
-            }
-            Regex(pattern, RegexOption.IGNORE_CASE)
-        }
-    }
+    /**
+     * Whether the opener whose `{{` starts at [openPos] is already balanced by a
+     * closer somewhere in [text]. Delegates the pairing to [QiqBlockModel] so the
+     * Enter handler and the block-range features agree on what counts as closed.
+     */
+    internal fun isOpenerClosed(text: CharSequence, openPos: Int): Boolean =
+        QiqBlockModel.computeBlockRanges(text).any { it.open.startOffset == openPos }
 
     // fromOffset 以降で最初の非空行テキストを返す
     private fun findNextNonEmptyLineText(

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/editor/QiqEnterHandlerLogicTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/editor/QiqEnterHandlerLogicTest.kt
@@ -16,10 +16,7 @@ class QiqEnterHandlerLogicTest {
             {{ endSection() }}
         """.trimIndent()
 
-        val openOffset = text.indexOf("}}") + 2
-        val hasCloser = handler.hasMatchingCloser(text, openOffset, "setSection", "endSection()")
-
-        assertTrue(hasCloser)
+        assertTrue(handler.isOpenerClosed(text, text.indexOf("{{ setSection")))
     }
 
     @Test
@@ -29,9 +26,15 @@ class QiqEnterHandlerLogicTest {
             <p>content</p>
         """.trimIndent()
 
-        val openOffset = text.indexOf("}}") + 2
-        val hasCloser = handler.hasMatchingCloser(text, openOffset, "setSection", "endSection()")
+        assertFalse(handler.isOpenerClosed(text, text.indexOf("{{ setSection")))
+    }
 
-        assertFalse(hasCloser)
+    @Test
+    fun semicolonTerminatedCloserCountsAsClosed() {
+        // Regression: {{ endif; }} must be recognised as the closer so Enter does
+        // not insert a duplicate {{ endif }}.
+        val text = "{{ if (\$x): }}\nbody\n{{ endif; }}"
+
+        assertTrue(handler.isOpenerClosed(text, text.indexOf("{{ if")))
     }
 }


### PR DESCRIPTION
## 概要
`QiqEnterHandler`(閉じタグ自動補完)と `QiqBlockModel`(#27 導入の共有基盤)が抱えていた**ブロック知識の二重持ち**を解消します。

> **Note**: #30 (PR #41) の上にスタックした PR です。base は `feat/block-inspection`。マージ順 #27→#28→#29→#30→#42 を想定。

## 変更内容
### 削除(重複)
- `blockClosers`(ブロックセットの複製)
- `openPatterns` / `closePatterns`(head ごとの正規表現群)
- `hasMatchingCloser`(正規表現 + depth カウント) / `MatchResultWrapper`
- 重複していた head 抽出・コロンルール

### 置換
- `QiqEnterHandler` は `QiqBlockModel.openerTypeOf(inside)` で「ブロック opener か」を判定(ブロックセット+コロンルールを一元化)し、挿入する閉じタグは `QiqBlockType.closeText` を使用
- `isOpenerClosed()` はペアリングを `QiqBlockModel.computeBlockRanges` に委譲 → Enter とブロック系機能で「閉じている」の判定が一致

### QiqBlockModel
- public `openerTypeOf(inner)` を追加(「ブロック opener か」の単一の真実)
- private `headOf()` を `scanDirectives` と共有 → head 抽出が 1 箇所に集約

## 副次効果(バグ解消)
EnterHandler の head 抽出は `;` を扱えず、`{{ endif; }}` を closer と認識できないため Enter で `{{ endif }}` を重複挿入していた。一元化により解消(#28 で `QiqBlockModel` 側は修正済み、本 PR で EnterHandler も追随)。

## テスト
- `QiqEnterHandlerLogicTest` を新 API(`isOpenerClosed`)に更新 + セミコロン終端の回帰ケース追加(3件)
- 全テスト通過(`QiqBlockModelTest` 18 / `QiqOutlineTest` 7 含む)、`buildPlugin` 成功
- 実機(PhpStorm)で Enter 補完が従来どおり動作することを確認(if/foreach/setSection 挿入・重複なし・コロン無しで非挿入)

## diff
3 files changed, 45 insertions(+), 94 deletions(-) — 差し引き約 -49 行。

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)