### PR TITLE
feat: inspection for unclosed / mismatched Qiq block directives (#30)

### DIFF
--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModel.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModel.kt
@@ -17,13 +17,14 @@ import java.util.Locale
 enum class QiqBlockType(
     val openHead: String,
     val closeHead: String,
+    val closeText: String,
     val requiresColon: Boolean,
 ) {
-    IF("if", "endif", true),
-    FOREACH("foreach", "endforeach", true),
-    FOR("for", "endfor", true),
-    SECTION("setSection", "endSection", false),
-    BLOCK("setBlock", "endBlock", false);
+    IF("if", "endif", "endif", true),
+    FOREACH("foreach", "endforeach", "endforeach", true),
+    FOR("for", "endfor", "endfor", true),
+    SECTION("setSection", "endSection", "endSection()", false),
+    BLOCK("setBlock", "endBlock", "endBlock()", false);
 
     companion object {
         private val byOpenHead = entries.associateBy { it.openHead.lowercase(Locale.ROOT) }
@@ -49,6 +50,28 @@ data class QiqBlockRange(
 
     /** The whole block, from the start of the opener to the end of the closer. */
     val fullRange: TextRange get() = TextRange(open.startOffset, close.endOffset)
+}
+
+/** A structurally invalid block directive found by [QiqBlockModel.validate]. */
+data class QiqBlockProblem(
+    val kind: Kind,
+    /** The offending `{{ ... }}` delimiter span. */
+    val range: TextRange,
+    /** The offending directive's own block type. */
+    val type: QiqBlockType,
+    /** For [Kind.MISMATCHED_CLOSER]: the nearest open block the closer failed to match. */
+    val expected: QiqBlockType? = null,
+) {
+    enum class Kind {
+        /** An opener that is never closed. */
+        UNCLOSED_OPENER,
+
+        /** A closer with no open block at all. */
+        UNMATCHED_CLOSER,
+
+        /** A closer whose type matches no open block, while a different block is open. */
+        MISMATCHED_CLOSER,
+    }
 }
 
 /**
@@ -130,35 +153,72 @@ object QiqBlockModel {
                 offset in block.close.startOffset..block.close.endOffset
         }
 
+    /**
+     * Report every structurally invalid block directive in [text]: openers that are
+     * never closed, closers with no opener, and closers that match no open block
+     * while a different block is open. Well-formed nested blocks produce nothing.
+     */
+    fun validate(text: CharSequence): List<QiqBlockProblem> {
+        val openers = ArrayDeque<Pending>()
+        val problems = ArrayList<QiqBlockProblem>()
+
+        for (directive in scanDirectives(text)) {
+            val openType = openTypeOf(directive)
+            if (openType != null) {
+                openers.addLast(Pending(openType, directive.range))
+                continue
+            }
+
+            val closeType = closeTypeOf(directive) ?: continue
+            if (openers.isEmpty()) {
+                problems.add(QiqBlockProblem(QiqBlockProblem.Kind.UNMATCHED_CLOSER, directive.range, closeType))
+                continue
+            }
+            if (openers.last().type == closeType) {
+                openers.removeLast() // proper match
+                continue
+            }
+
+            val matchIndex = openers.indexOfLast { it.type == closeType }
+            if (matchIndex >= 0) {
+                // A matching opener is open deeper down; the inner ones above it are unclosed.
+                for (k in openers.indices.reversed()) {
+                    if (k <= matchIndex) break
+                    problems.add(QiqBlockProblem(QiqBlockProblem.Kind.UNCLOSED_OPENER, openers[k].delimiter, openers[k].type))
+                }
+                while (openers.size > matchIndex) openers.removeLast()
+            } else {
+                // No opener of this type anywhere: the closer is wrong for the nearest opener.
+                problems.add(
+                    QiqBlockProblem(
+                        QiqBlockProblem.Kind.MISMATCHED_CLOSER,
+                        directive.range,
+                        closeType,
+                        expected = openers.last().type,
+                    ),
+                )
+            }
+        }
+
+        for (opener in openers) {
+            problems.add(QiqBlockProblem(QiqBlockProblem.Kind.UNCLOSED_OPENER, opener.delimiter, opener.type))
+        }
+
+        return problems.sortedBy { it.range.startOffset }
+    }
+
     private fun accept(
         directive: Directive,
         openers: ArrayDeque<Pending>,
         result: MutableList<QiqBlockRange>,
     ) {
-        val openType = QiqBlockType.forOpenHead(directive.head)
-        // Every opener is a call/condition form whose '(' follows the head directly
-        // (whitespace allowed). Requiring the '(' right after the head rejects bare
-        // `{{ if $x: }}` / `{{ setSection 'a' }}` and avoids a false positive when an
-        // inner call supplies the '(' (e.g. `{{ if $x && foo(): }}`). if/foreach/for
-        // additionally require the trailing alternative-syntax colon; testing the
-        // trailing colon (not any colon) keeps a ternary `?:` from being mistaken for one.
-        if (openType != null &&
-            directive.inner.substring(directive.head.length).trimStart().startsWith("(") &&
-            (!openType.requiresColon || directive.inner.trimEnd().endsWith(':'))
-        ) {
+        val openType = openTypeOf(directive)
+        if (openType != null) {
             openers.addLast(Pending(openType, directive.range))
             return
         }
 
-        val closeType = QiqBlockType.forCloseHead(directive.head) ?: return
-        // setSection/setBlock are call-style: only an empty-arg call closes them
-        // (`{{ endSection() }}`, optional trailing `;`). Anything else — no parens,
-        // or arguments — is invalid and must not pair.
-        if ((closeType == QiqBlockType.SECTION || closeType == QiqBlockType.BLOCK) &&
-            !isEmptyArgClose(directive.inner, closeType)
-        ) {
-            return
-        }
+        val closeType = closeTypeOf(directive) ?: return
         val matchIndex = openers.indexOfLast { it.type == closeType }
         if (matchIndex < 0) return // unmatched closer
 
@@ -166,6 +226,33 @@ object QiqBlockModel {
         // Drop the matched opener and any inner blocks left unclosed above it.
         while (openers.size > matchIndex) openers.removeLast()
         result.add(QiqBlockRange(closeType, opener.delimiter, directive.range))
+    }
+
+    /**
+     * The block type this directive opens, or null. Every opener is a call/condition
+     * form whose '(' follows the head directly (whitespace allowed); requiring it there
+     * rejects bare `{{ if $x: }}` / `{{ setSection 'a' }}` and avoids a false positive
+     * when an inner call supplies the '(' (e.g. `{{ if $x && foo(): }}`). if/foreach/for
+     * additionally require the trailing alternative-syntax colon; testing the trailing
+     * colon (not any colon) keeps a ternary `?:` from being mistaken for one.
+     */
+    private fun openTypeOf(directive: Directive): QiqBlockType? =
+        QiqBlockType.forOpenHead(directive.head)?.takeIf {
+            directive.inner.substring(directive.head.length).trimStart().startsWith("(") &&
+                (!it.requiresColon || directive.inner.trimEnd().endsWith(':'))
+        }
+
+    /**
+     * The block type this directive closes, or null. `setSection`/`setBlock` are
+     * call-style: only an empty-arg call (`endSection()` / `endBlock()`, optional
+     * trailing `;`) closes them; no parens, or arguments, is invalid and must not pair.
+     */
+    private fun closeTypeOf(directive: Directive): QiqBlockType? {
+        val type = QiqBlockType.forCloseHead(directive.head) ?: return null
+        if ((type == QiqBlockType.SECTION || type == QiqBlockType.BLOCK) && !isEmptyArgClose(directive.inner, type)) {
+            return null
+        }
+        return type
     }
 
     /** True if [inner] is an empty-arg call closer, e.g. `endSection()` / `endBlock() ;`. */

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inspection/QiqBlockDirectiveInspection.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inspection/QiqBlockDirectiveInspection.kt
@@ -1,0 +1,49 @@
+package io.github.jingu.idea_qiq_plugin.inspection
+
+import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.psi.PsiFile
+import io.github.jingu.idea_qiq_plugin.block.QiqBlockModel
+import io.github.jingu.idea_qiq_plugin.block.QiqBlockProblem
+import io.github.jingu.idea_qiq_plugin.lang.QiqTemplateLanguage
+import io.github.jingu.idea_qiq_plugin.ui.QiqBundle
+
+/**
+ * Warns on structurally invalid Qiq blocks: an opener with no closer, a closer
+ * with no opener, and a closer that does not match the nearest open block
+ * (e.g. `{{ foreach }}` … `{{ endif }}`).
+ *
+ * Pairing is delegated to [QiqBlockModel.validate], the same model that drives
+ * folding, block matching, and the structure view, so the warnings line up with
+ * those features. Runs on the whole file at once rather than per element.
+ */
+class QiqBlockDirectiveInspection : LocalInspectionTool() {
+
+    override fun checkFile(file: PsiFile, manager: InspectionManager, isOnTheFly: Boolean): Array<ProblemDescriptor>? {
+        if (!file.language.isKindOf(QiqTemplateLanguage)) return null
+
+        val problems = QiqBlockModel.validate(file.text)
+        if (problems.isEmpty()) return null
+
+        return problems.map { problem ->
+            manager.createProblemDescriptor(
+                file,
+                problem.range,
+                message(problem),
+                ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+                isOnTheFly,
+            )
+        }.toTypedArray()
+    }
+
+    private fun message(problem: QiqBlockProblem): String = when (problem.kind) {
+        QiqBlockProblem.Kind.UNCLOSED_OPENER ->
+            QiqBundle.message("inspection.block.unclosed", problem.type.openHead, problem.type.closeText)
+        QiqBlockProblem.Kind.UNMATCHED_CLOSER ->
+            QiqBundle.message("inspection.block.unmatched", problem.type.closeText)
+        QiqBlockProblem.Kind.MISMATCHED_CLOSER ->
+            QiqBundle.message("inspection.block.mismatched", problem.type.closeText, problem.expected!!.openHead)
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -74,6 +74,17 @@
                 language="Qiq"
                 implementationClass="io.github.jingu.idea_qiq_plugin.structure.QiqStructureViewFactory"/>
 
+        <!-- Warn on structurally invalid Qiq blocks: unclosed openers, closers
+             with no opener, and closers that do not match the nearest open
+             block. Shares the block-range model with folding/matching/structure. -->
+        <localInspection
+                language="Qiq"
+                implementationClass="io.github.jingu.idea_qiq_plugin.inspection.QiqBlockDirectiveInspection"
+                groupKey="inspection.group.qiq"
+                key="inspection.block.directive.name"
+                enabledByDefault="true"
+                level="WARNING"/>
+
         <!-- Color Settings Page -->
         <colorSettingsPage implementation="io.github.jingu.idea_qiq_plugin.ui.QiqColorSettingsPage"/>
 

--- a/src/main/resources/messages/QiqBundle.properties
+++ b/src/main/resources/messages/QiqBundle.properties
@@ -24,3 +24,7 @@ inspection.helper.argcount.few=Too few arguments to helper ''{0}'': expected at 
 inspection.helper.argcount.many=Too many arguments to helper ''{0}'': expected at most {1}, got {2}
 inspection.helper.argcount.invalid=Invalid number of arguments to helper ''{0}'': {1} matches none of its signatures
 inspection.helper.argtype.mismatch=Argument {0} of helper ''{1}'': expected {2}, got {3}
+inspection.block.directive.name=Qiq block directive pairing
+inspection.block.unclosed=Unclosed Qiq block ''{0}'': missing ''{1}''
+inspection.block.unmatched=Qiq closer ''{0}'' has no matching opener
+inspection.block.mismatched=Qiq closer ''{0}'' does not match the open ''{1}''

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModelTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModelTest.kt
@@ -238,6 +238,60 @@ class QiqBlockModelTest {
     }
 
     @Test
+    fun validateAcceptsWellFormedNesting() {
+        val text = """
+            {{ setSection('a') }}
+            {{ if (${'$'}x): }}
+            {{ foreach (${'$'}xs as ${'$'}y): }}
+            x
+            {{ endforeach }}
+            {{ endif }}
+            {{ endSection() }}
+        """.trimIndent()
+
+        assertTrue(QiqBlockModel.validate(text).isEmpty())
+    }
+
+    @Test
+    fun validateFlagsUnclosedOpener() {
+        val text = "{{ if (${'$'}x): }}\n<p>no end</p>"
+        val problem = QiqBlockModel.validate(text).single()
+        assertEquals(QiqBlockProblem.Kind.UNCLOSED_OPENER, problem.kind)
+        assertEquals(QiqBlockType.IF, problem.type)
+        assertEquals(text.indexOf("{{ if"), problem.range.startOffset)
+    }
+
+    @Test
+    fun validateFlagsUnmatchedCloser() {
+        val text = "<p>x</p>\n{{ endif }}"
+        val problem = QiqBlockModel.validate(text).single()
+        assertEquals(QiqBlockProblem.Kind.UNMATCHED_CLOSER, problem.kind)
+        assertEquals(QiqBlockType.IF, problem.type)
+    }
+
+    @Test
+    fun validateFlagsMismatchedCloser() {
+        // foreach opened, endif seen: endif matches no open block (mismatch),
+        // and the foreach is left unclosed.
+        val text = "{{ foreach (${'$'}xs as ${'$'}y): }}\nx\n{{ endif }}"
+        val problems = QiqBlockModel.validate(text)
+        val mismatch = problems.single { it.kind == QiqBlockProblem.Kind.MISMATCHED_CLOSER }
+        assertEquals(QiqBlockType.IF, mismatch.type)
+        assertEquals(QiqBlockType.FOREACH, mismatch.expected)
+        assertTrue(problems.any { it.kind == QiqBlockProblem.Kind.UNCLOSED_OPENER && it.type == QiqBlockType.FOREACH })
+    }
+
+    @Test
+    fun validateFlagsInnerUnclosedOnWrongNesting() {
+        // The inner foreach is never closed; the endif still closes the if.
+        val text = "{{ if (${'$'}x): }}\n{{ foreach (${'$'}xs as ${'$'}y): }}\n{{ endif }}"
+        val problems = QiqBlockModel.validate(text)
+        assertEquals(1, problems.size)
+        assertEquals(QiqBlockProblem.Kind.UNCLOSED_OPENER, problems[0].kind)
+        assertEquals(QiqBlockType.FOREACH, problems[0].type)
+    }
+
+    @Test
     fun bodyRangeExcludesDelimiters() {
         val text = "{{ if (${'$'}x): }}BODY{{ endif }}"
         val block = ranges(text).single()


### PR DESCRIPTION
## 概要
Epic #37 Tier 1 の **#30**。構造的に不正な Qiq ブロックを警告する inspection を追加します。

> **Note**: 旧 PR #41 がスタックのリベース作業中に GitHub 側で CLOSE され、API で reopen できなくなったため（HTTP 422「no new commits」）、内容そのままで作り直した代替 PR です。ブランチ `feat/block-inspection`(476db2b) の内容は無傷で、旧 #41 と同一です。base は `feat/structure-view`(#40 / PR #40)。

## 変更内容
- `block/QiqBlockModel.kt`: `validate(text)` を追加。スタックで厳密なネスト検証を行い `UNCLOSED_OPENER` / `UNMATCHED_CLOSER` / `MISMATCHED_CLOSER` を検出。`openTypeOf`/`closeTypeOf` に共通化（コロンルール・call-style closer の空括弧必須を含む）。`QiqBlockType` に `closeText` 追加。
- `inspection/QiqBlockDirectiveInspection.kt` (新規): `LocalInspectionTool`(language=Qiq)、`checkFile` で全体検証し `QiqBlockModel.validate()` に委譲。
- `QiqBundle.properties` / `plugin.xml`: メッセージ3種、`localInspection` 登録。

## テスト
- `QiqBlockModelTest` に validate 系を含む計25ケース、全通過。実機(PhpStorm)で動作確認済み。

## Acceptance (#30)
- [x] Missing/extra/mismatched closers each produce a clear warning
- [x] No false positives on well-formed nested blocks; unit-tested

Closes #30