### PR TITLE
fix: use half-open ranges in QiqBlockModel.blockAtDelimiter (#44)

### DIFF
--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModel.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModel.kt
@@ -140,14 +140,14 @@ object QiqBlockModel {
     /**
      * The block whose opener or closer delimiter [offset] falls on, if any.
      *
-     * A delimiter spans `{{ ... }}` inclusive of both ends, so a caret resting at
-     * either edge of an opener or closer still resolves to its block. Used to drive
-     * block-pair highlighting.
+     * Offsets follow IntelliJ's half-open `[start, end)` semantics, so the position
+     * right after a `}}` is outside its delimiter: where two delimiters are adjacent
+     * (`}}{{`), the boundary offset resolves only to the following block. Used to
+     * drive block-pair highlighting.
      */
     fun blockAtDelimiter(text: CharSequence, offset: Int): QiqBlockRange? =
         computeBlockRanges(text).firstOrNull { block ->
-            offset in block.open.startOffset..block.open.endOffset ||
-                offset in block.close.startOffset..block.close.endOffset
+            block.open.contains(offset) || block.close.contains(offset)
         }
 
     /**

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModelTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModelTest.kt
@@ -238,6 +238,28 @@ class QiqBlockModelTest {
     }
 
     @Test
+    fun blockAtDelimiterUsesHalfOpenRanges() {
+        // Regression (#44): delimiter ranges are half-open [start, end), so the
+        // offset right after a closer's `}}` is outside that block.
+        val text = "{{ if (${'$'}x): }}body{{ endif }}"
+        assertEquals(null, QiqBlockModel.blockAtDelimiter(text, text.length))
+        // The last offset inside the closer still resolves.
+        assertEquals(QiqBlockType.IF, QiqBlockModel.blockAtDelimiter(text, text.length - 1)?.type)
+    }
+
+    @Test
+    fun blockAtDelimiterAdjacentDelimitersResolveToFollowingBlock() {
+        // Regression (#44): at a `}}{{` boundary the offset is the first closer's
+        // endOffset AND the second opener's startOffset; it must resolve to the
+        // following block only, never the preceding one.
+        val text = "{{ if (${'$'}a): }}x{{ endif }}{{ if (${'$'}b): }}y{{ endif }}"
+        val boundary = text.indexOf("}}{{") + 2
+
+        val block = QiqBlockModel.blockAtDelimiter(text, boundary)
+        assertEquals(text.indexOf("{{ if (${'$'}b)"), block?.open?.startOffset)
+    }
+
+    @Test
     fun validateAcceptsWellFormedNesting() {
         val text = """
             {{ setSection('a') }}


### PR DESCRIPTION
## Summary
- `blockAtDelimiter` tested the caret offset against delimiter ranges with `..` (inclusive of both ends), but `TextRange.endOffset` is exclusive — the position right after `}}` still counted as inside the delimiter. At a `}}{{` boundary the offset matched both the preceding and the following block, mis-resolving block-pair highlighting.
- Switched to `TextRange.contains(offset)` (half-open `[start, end)`); at an adjacent boundary the offset now resolves only to the following block.

## Note on the issue's suggested fix
#44's scope suggests `containsOffset()`, but that method is **inclusive** of `endOffset` (`start <= offset && offset <= end` — verified against the platform bytecode), i.e. identical to the old behavior. `contains(int)` is the half-open variant that matches the issue's stated intent ("follow IntelliJ's half-open semantics").

## Tests
- `blockAtDelimiterUsesHalfOpenRanges` — offset right after a closer's `}}` no longer resolves; the last offset inside still does.
- `blockAtDelimiterAdjacentDelimitersResolveToFollowingBlock` — the `}}{{` boundary resolves to the following block, never the preceding one.
- Full suite: 102 tests, 0 failures.

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)