### PR TITLE
chore: prepare 0.10.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Qiq Templates Support is an IntelliJ-based plugin that brings syntax highlightin
 - **Block matching & pair highlighting**: Qiq delimiters (`{{`, `{{=`, `{{h`, etc.) pair with their closing `}}` without matching braces from injected PHP or HTML, and the caret on a block opener/closer highlights its partner directive — nested same-keyword blocks resolve correctly.
 - **Structure view**: the Structure tool window (Alt+7 / Cmd+7) outlines sections/blocks by name, nested control blocks, and top-level `setLayout()`/`extends()` directives, with click-to-navigate.
 - **Block directive inspection**: warns on an unclosed opener, a closer with no opener, and a closer that doesn't match the nearest open block (`{{ foreach }}`…`{{ endif }}`).
+- **Section names as symbols**: section names complete in `getSection('…')` / `hasSection('…')` from the `setSection` definitions across the template roots; Go to Declaration jumps both ways (reader → definitions, `setSection` → usages, with file/line shown), even when a name collides with a PHP function; an inspection flags a `getSection('x')` that no template defines. `$this->`-qualified directives (`$this->setSection(...)` … `$this->endSection()`) fold, pair, resolve, and argument-check like the bare form.
 - **Enter/typing handlers** that auto-complete Qiq block closers and keep indentation consistent.
 - **Template discovery**: resolves relative paths by walking up from the current file, project roots, and PHP server document roots.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ intellijPlatform {
     pluginConfiguration {
         name.set("Qiq Templates Support")
         id.set("io.github.jingu.idea-qiq-plugin")
-        version.set("0.9.0")
+        version.set("0.10.0")
         ideaVersion {
             sinceBuild.set("241")
             untilBuild.set("261.*")

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -254,7 +254,7 @@
 <ul>
   <li><b>Section names as symbols</b>
     <ul>
-      <li>Completion of section names in <code>getSection('|')</code> / <code>hasSection('|')</code>, drawn from the <code>setSection</code> definitions across the detected template roots.</li>
+      <li>Completion of section names in <code>getSection('&hellip;')</code> / <code>hasSection('&hellip;')</code>, drawn from the <code>setSection</code> definitions across the detected template roots.</li>
       <li>Go to Declaration both ways: <code>getSection</code>/<code>hasSection</code> jump to the matching <code>setSection</code> definitions, and <code>setSection</code> jumps to its <code>getSection</code>/<code>hasSection</code> usages (the chooser shows each target's file and line). Works even when the name collides with a PHP function such as <code>'header'</code>.</li>
       <li>Inspection: a <code>getSection('x')</code> whose name no template defines is flagged (conservatively &mdash; <code>hasSection</code> is left alone, since it tests a possibly-absent name).</li>
     </ul>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -252,30 +252,22 @@
     </actions>
     <change-notes><![CDATA[
 <ul>
-  <li><b>Code folding for Qiq blocks</b>
+  <li><b>Section names as symbols</b>
     <ul>
-      <li><code>{{ if (...): }}</code>&hellip;<code>{{ endif }}</code>, <code>foreach</code>, <code>for</code>, <code>setSection</code>, and <code>setBlock</code> blocks can be collapsed. Only the body folds, so a collapsed block still reads as <code>{{ if (...): }}&hellip;{{ endif }}</code>.</li>
+      <li>Completion of section names in <code>getSection('|')</code> / <code>hasSection('|')</code>, drawn from the <code>setSection</code> definitions across the detected template roots.</li>
+      <li>Go to Declaration both ways: <code>getSection</code>/<code>hasSection</code> jump to the matching <code>setSection</code> definitions, and <code>setSection</code> jumps to its <code>getSection</code>/<code>hasSection</code> usages (the chooser shows each target's file and line). Works even when the name collides with a PHP function such as <code>'header'</code>.</li>
+      <li>Inspection: a <code>getSection('x')</code> whose name no template defines is flagged (conservatively &mdash; <code>hasSection</code> is left alone, since it tests a possibly-absent name).</li>
     </ul>
   </li>
-  <li><b>Block matching &amp; brace highlighting</b>
+  <li><b><code>$this-&gt;</code>-qualified Qiq calls</b>
     <ul>
-      <li>Qiq delimiters (<code>{{</code> / <code>{{=</code> / <code>{{h</code> / <code>{{a</code> / <code>{{c</code> / <code>{{j</code> / <code>{{u</code>) pair with their closing <code>}}</code>, without ever pairing against a brace from injected PHP or surrounding HTML.</li>
-      <li>Resting the caret on a block opener or closer highlights its partner directive &mdash; nested same-keyword blocks (<code>if</code> inside <code>if</code>) resolve to the correct partner.</li>
+      <li><code>{{ $this-&gt;setSection('x') }}</code>&hellip;<code>{{ $this-&gt;endSection() }}</code> now fold, pair, and validate like the bare form.</li>
+      <li><code>$this-&gt;setSection(...)</code> and the other template methods resolve for Go to Declaration and argument checks, while dynamic data (<code>$this-&gt;var</code>) and helper calls keep working without false warnings.</li>
     </ul>
   </li>
-  <li><b>Structure view (outline)</b>
+  <li><b>Unified template-path resolution</b>
     <ul>
-      <li>The Structure tool window (Alt+7 / Cmd+7) shows <code>setSection</code>/<code>setBlock</code> by name, nested control blocks (<code>if</code>/<code>foreach</code>/<code>for</code>), and top-level <code>setLayout()</code>/<code>extends()</code> directives. Clicking a node navigates to the directive.</li>
-    </ul>
-  </li>
-  <li><b>Inspection: unclosed / mismatched block directives</b>
-    <ul>
-      <li>Warns on an opener that is never closed (<code>{{ if (...): }}</code> without <code>{{ endif }}</code>), a closer with no opener, and a closer that does not match the nearest open block (e.g. <code>{{ foreach }}</code>&hellip;<code>{{ endif }}</code>).</li>
-    </ul>
-  </li>
-  <li><b>More accurate Enter auto-close</b>
-    <ul>
-      <li>Pressing Enter after a block opener now uses the same block pairing as folding/matching, so semicolon-terminated closers (<code>{{ endif; }}</code>) are recognised and a duplicate closer is no longer inserted.</li>
+      <li>Path completion, Go to Declaration, and the missing-template inspection now share a single resolver, so a path that completes is a path that navigates and is not falsely flagged &mdash; removing edge-case disagreements in unusual template layouts.</li>
     </ul>
   </li>
 </ul>


### PR DESCRIPTION
## Summary
Bump the plugin version to **0.10.0** and refresh the release notes / README for the work merged since 0.9.0.

This is an interim **0.x** release of the completed roadmap items — **not** 1.0, which still needs Tier-1 #32 (test-suite hardening) and Tier-2 (#33–#35) per the epic #37.

## Included since 0.9.0
- **#49 (#31) — Section names as symbols**: completion of section names in `getSection('…')` / `hasSection('…')`; Go to Declaration both ways (reader → `setSection` definitions, `setSection` → usages, with file/line in the chooser), incl. names colliding with PHP functions; undefined-section inspection. Plus `$this->`-qualified directive pairing/folding/validation and stub resolution (`$this->setSection(...)` Go to Declaration + argument checks, with dynamic data/helper access unflagged).
- **#48 (#22) — Unified template-path resolution**: completion, navigation, and the missing-template inspection share one resolver (completable = navigable = not-warned).

## Changes
- `build.gradle.kts` — `version.set("0.10.0")`
- `plugin.xml` — `<change-notes>` rewritten for 0.10.0
- `README.md` — section-names feature bullet added

## Verification
- `./gradlew test` — all tests pass
- `./gradlew buildPlugin` — built jar is `QiqLanguagePlugin-0.10.0.jar` with `<version>0.10.0</version>` confirmed inside

## Release steps (after merge to develop)
Merge `develop` → `main`, tag `0.10.0`, create the GitHub Release, then upload the built ZIP to the JetBrains Marketplace (Stable channel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)