### PR TITLE
feat: recognize appendSection / prependSection as section definitions

### DIFF
--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModel.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModel.kt
@@ -9,25 +9,32 @@ import java.util.Locale
  * Shares its directive set with [io.github.jingu.idea_qiq_plugin.editor.QiqEnterHandler]
  * (which auto-closes the same blocks). `if`/`foreach`/`for` use PHP alternative syntax,
  * so an opener is only a block when it is colon-terminated (`{{ if (...): }}`);
- * `setSection` / `setBlock` are call-style openers. The exact opener/closer parsing
- * here is deliberately stricter than the keyword set alone to avoid pairing
- * syntactically invalid directives. Heads are matched case-insensitively, as PHP
- * keywords and method names are.
+ * `setSection` / `setBlock` are call-style openers. A section is opened three ways —
+ * `setSection` (replace), `appendSection`, `prependSection` ([altOpenHeads]) — all
+ * paired with the same `endSection()` closer. The exact opener/closer parsing here is
+ * deliberately stricter than the keyword set alone to avoid pairing syntactically
+ * invalid directives. Heads are matched case-insensitively, as PHP keywords and
+ * method names are.
  */
 enum class QiqBlockType(
     val openHead: String,
     val closeHead: String,
     val closeText: String,
     val requiresColon: Boolean,
+    /** Extra openers that pair with the same closer, e.g. append/prepend for a section. */
+    val altOpenHeads: List<String> = emptyList(),
 ) {
     IF("if", "endif", "endif", true),
     FOREACH("foreach", "endforeach", "endforeach", true),
     FOR("for", "endfor", "endfor", true),
-    SECTION("setSection", "endSection", "endSection()", false),
+    SECTION("setSection", "endSection", "endSection()", false, altOpenHeads = listOf("appendSection", "prependSection")),
     BLOCK("setBlock", "endBlock", "endBlock()", false);
 
+    /** Every recognised opener head for this block: the primary plus any [altOpenHeads]. */
+    val openHeads: List<String> get() = listOf(openHead) + altOpenHeads
+
     companion object {
-        private val byOpenHead = entries.associateBy { it.openHead.lowercase(Locale.ROOT) }
+        private val byOpenHead = entries.flatMap { type -> type.openHeads.map { it.lowercase(Locale.ROOT) to type } }.toMap()
         private val byCloseHead = entries.associateBy { it.closeHead.lowercase(Locale.ROOT) }
 
         fun forOpenHead(head: String): QiqBlockType? = byOpenHead[head.lowercase(Locale.ROOT)]

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqSectionModel.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqSectionModel.kt
@@ -3,12 +3,14 @@ package io.github.jingu.idea_qiq_plugin.block
 import com.intellij.openapi.util.TextRange
 
 /**
- * A section name *definition* — a `setSection('name')` directive — found in raw
- * template text. [nameRange] is the span of the name itself (inside the quotes),
- * so a reference can navigate straight to the name.
+ * A section name *definition* — a `setSection`/`appendSection`/`prependSection`
+ * directive — found in raw template text. [head] is the directive name as written
+ * (so a navigation target can label itself accurately), and [nameRange] is the span
+ * of the name itself (inside the quotes), so a reference can navigate straight to it.
  */
 data class QiqSectionDef(
     val name: String,
+    val head: String,
     val nameRange: TextRange,
 )
 
@@ -45,8 +47,10 @@ object QiqSectionModel {
     private val READER = Regex("(?i)(?:\\\$this\\s*->\\s*|(?<![-:>\\w\$]))(getSection|hasSection)\\s*\\(\\s*(['\"])(.*?)\\2")
 
     /**
-     * Every `setSection` name definition in [text], in document order. Directives
-     * with no quoted name, or an empty name, are skipped.
+     * Every section name definition in [text], in document order — `setSection`,
+     * `appendSection`, and `prependSection` all define a section (they differ only in
+     * how Qiq merges content). Directives with no quoted name, or an empty name, are
+     * skipped.
      */
     fun definitions(text: CharSequence): List<QiqSectionDef> {
         val result = ArrayList<QiqSectionDef>()
@@ -54,7 +58,7 @@ object QiqSectionModel {
             if (QiqBlockModel.openerTypeOf(directive.inner) != QiqBlockType.SECTION) continue
             val nameRange = firstArgQuotedRange(text, directive.range) ?: continue
             if (nameRange.isEmpty) continue
-            result.add(QiqSectionDef(text.substring(nameRange.startOffset, nameRange.endOffset), nameRange))
+            result.add(QiqSectionDef(text.substring(nameRange.startOffset, nameRange.endOffset), directive.head, nameRange))
         }
         return result
     }

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/util/QiqSectionCall.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/util/QiqSectionCall.kt
@@ -8,9 +8,9 @@ import com.jetbrains.php.lang.psi.elements.Variable
 import java.util.Locale
 
 /**
- * Recognizes the Qiq section calls — `setSection('name')` (the definition),
- * `getSection('name')` / `hasSection('name')` (the readers) — bare or
- * `$this->`-qualified. Shared by the name completion, navigation, and the
+ * Recognizes the Qiq section calls — `setSection`/`appendSection`/`prependSection`
+ * (the definitions), `getSection('name')` / `hasSection('name')` (the readers) —
+ * bare or `$this->`-qualified. Shared by the name completion, navigation, and the
  * undefined-name inspection so they agree on what counts as a section call.
  *
  * Only sections are handled here: blocks read with an argument-less `getBlock()`,
@@ -26,13 +26,15 @@ object QiqSectionCall {
      *  legitimately tests a possibly-absent name, so a missing one is not a bug. */
     private const val INSPECTABLE_READER = "getsection"
 
-    private const val WRITER_HEAD = "setsection"
+    /** Definition writers: a section is defined by replace/append/prepend, all
+     *  closed with `endSection()`. */
+    private val WRITER_HEADS = setOf("setsection", "appendsection", "prependsection")
 
     /** True if [literal] is the name argument of a `getSection`/`hasSection` reader. */
     fun isReaderArg(literal: StringLiteralExpression): Boolean = headOfArg(literal) in READER_HEADS
 
-    /** True if [literal] is the name argument of a `setSection` definition. */
-    fun isWriterArg(literal: StringLiteralExpression): Boolean = headOfArg(literal) == WRITER_HEAD
+    /** True if [literal] is the name argument of a `setSection`/`appendSection`/`prependSection` definition. */
+    fun isWriterArg(literal: StringLiteralExpression): Boolean = headOfArg(literal) in WRITER_HEADS
 
     /** True if [call] is a `getSection` reader (for the inspection; `hasSection` excluded). */
     fun isInspectableReader(call: FunctionReference): Boolean = headOfCall(call) == INSPECTABLE_READER

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/util/QiqSectionIndex.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/util/QiqSectionIndex.kt
@@ -127,7 +127,7 @@ object QiqSectionIndex {
                 remaining--
                 val text = readText(child) ?: continue
                 for (def in QiqSectionModel.definitions(text)) {
-                    definitions.add(QiqSectionLocation(child, def.name, "setSection", def.nameRange))
+                    definitions.add(QiqSectionLocation(child, def.name, def.head, def.nameRange))
                 }
                 for (use in QiqSectionModel.usages(text)) {
                     usages.add(QiqSectionLocation(child, use.name, use.head, use.nameRange))

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModelTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqBlockModelTest.kt
@@ -70,6 +70,25 @@ class QiqBlockModelTest {
     }
 
     @Test
+    fun pairsAppendAndPrependSectionWithEndSection() {
+        // A section is opened three ways — set/append/prepend — all closed by
+        // endSection(); append/prepend must pair just like setSection (#50).
+        val append = "{{ appendSection('a') }}x{{ endSection() }}"
+        assertEquals(QiqBlockType.SECTION, ranges(append).single().type)
+
+        val prepend = "{{ ${'$'}this->prependSection('b') }}y{{ ${'$'}this->endSection() }}"
+        assertEquals(QiqBlockType.SECTION, ranges(prepend).single().type)
+    }
+
+    @Test
+    fun appendAndPrependSectionAreNotUnmatchedClosers() {
+        // Regression (#50): with only setSection known as an opener, the endSection()
+        // after append/prepend was wrongly flagged as an unmatched closer.
+        assertTrue(QiqBlockModel.validate("{{ appendSection('a') }}x{{ endSection() }}").isEmpty())
+        assertTrue(QiqBlockModel.validate("{{ prependSection('b') }}y{{ endSection() }}").isEmpty())
+    }
+
+    @Test
     fun pairsThisQualifiedSectionCalls() {
         // `{{ $this->setSection('x') }}` is the explicit form of `{{ setSection('x') }}`
         // (Qiq compiles the bare call to `$this->...`); both must pair, including a

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqSectionModelTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/block/QiqSectionModelTest.kt
@@ -18,6 +18,21 @@ class QiqSectionModelTest {
     }
 
     @Test
+    fun recognisesAppendAndPrependSectionAsDefinitions() {
+        // A section is also defined by appendSection/prependSection, not just
+        // setSection (#50); each definition records the head as written.
+        val text = """
+            {{ setSection('a') }}x{{ endSection() }}
+            {{ appendSection('b') }}y{{ endSection() }}
+            {{ ${'$'}this->prependSection('c') }}z{{ endSection() }}
+        """.trimIndent()
+
+        val defs = QiqSectionModel.definitions(text)
+        assertEquals(listOf("a", "b", "c"), defs.map { it.name })
+        assertEquals(listOf("setSection", "appendSection", "prependSection"), defs.map { it.head })
+    }
+
+    @Test
     fun nameRangePointsAtTheNameInsideQuotes() {
         val text = "{{ setSection('header') }}"
         val def = QiqSectionModel.definitions(text).single()


### PR DESCRIPTION
## Summary

Treats `appendSection('name')` and `prependSection('name')` as first-class **section definitions**, on par with `setSection('name')`, across both the name-navigation feature and the structural block features.

Qiq's section API defines a section three ways, all paired with `endSection()`:

```php
protected function setSection(string $name) : void      // replace
protected function appendSection(string $name) : void   // append to existing
protected function prependSection(string $name) : void  // prepend to existing
```

`#31` shipped section-name support but only recognized `setSection`. Templates using append/prepend were therefore mishandled — and the block-directive inspection flagged their `endSection()` as an **unmatched closer** (a false positive).

## Changes

- **`QiqBlockType`** (`block/QiqBlockModel.kt`): add `altOpenHeads`; `SECTION` now opens with `appendSection`/`prependSection` too. Folding, structure view, brace matching, and block validation all follow automatically through the shared model.
- **`QiqSectionModel` / `QiqSectionDef`** (`block/QiqSectionModel.kt`): `definitions()` now includes append/prepend and records the directive `head` as written, so navigation targets label themselves accurately.
- **`QiqSectionCall.isWriterArg`** (`util/QiqSectionCall.kt`): treats append/prepend as definition writers (`setSection → usages` navigation direction).
- **`QiqSectionIndex`** (`util/QiqSectionIndex.kt`): labels definitions by their actual head instead of a hardcoded `"setSection"`.

`QiqSectionNameInspection` (undefined-name) and `QiqOutline` (structure view) need no change — they go through `definitions()` / `openerTypeOf()` and follow automatically.

## Tests

- `QiqBlockModelTest`: append/prepend pair with `endSection()`; no false "unmatched closer".
- `QiqSectionModelTest`: append/prepend recognized as definitions with the correct head.
- Full suite green; manually verified in PhpStorm (inspection, folding, structure view, brace matching, navigation).

Closes #50. Part of the 1.0 roadmap epic #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)