### PR TITLE
feat: directive keyword completion + Live Templates for Qiq blocks

### DIFF
--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/completion/QiqDirectiveCompletionContributor.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/completion/QiqDirectiveCompletionContributor.kt
@@ -1,0 +1,123 @@
+package io.github.jingu.idea_qiq_plugin.completion
+
+import com.intellij.codeInsight.completion.CompletionContributor
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionProvider
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.codeInsight.completion.InsertHandler
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.lang.injection.InjectedLanguageManager
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.util.ProcessingContext
+import io.github.jingu.idea_qiq_plugin.lang.QiqInjectionSupport
+import io.github.jingu.idea_qiq_plugin.psi.QiqCodeHost
+
+/**
+ * Completes Qiq directive keywords at the head of a plain `{{ | }}` block:
+ * control directives (`if`/`foreach`/`for` and their `else`/`end*` partners) and
+ * the template API (`setSection`/`getSection`/`setLayout`/`extends`, ...).
+ *
+ * Fires only at the *head* of a non-print code block — where nothing but
+ * whitespace precedes the caret inside the `{{ }}` — so keywords are not offered
+ * mid-expression or inside `{{= }}` / `{{h }}` output tags (those already get
+ * helper and section-name completion). Call-style directives insert with `()` and
+ * the caret between the parens, mirroring [QiqHelperCompletionContributor].
+ */
+class QiqDirectiveCompletionContributor : CompletionContributor() {
+
+    init {
+        extend(
+            CompletionType.BASIC,
+            // Broad position pattern; the real gating (Qiq file + directive-head
+            // position) happens in the provider where the injection is known.
+            PlatformPatterns.psiElement(),
+            DirectiveCompletionProvider(),
+        )
+    }
+
+    private class DirectiveCompletionProvider : CompletionProvider<CompletionParameters>() {
+        override fun addCompletions(
+            parameters: CompletionParameters,
+            context: ProcessingContext,
+            result: CompletionResultSet,
+        ) {
+            val position = parameters.position
+            if (!QiqInjectionSupport.isInQiqFile(position)) return
+
+            val ilm = InjectedLanguageManager.getInstance(position.project)
+            val host = ilm.getInjectionHost(position) as? QiqCodeHost ?: return
+            // Output tags (`{{= }}`, `{{h }}`, ...) take an expression, not a
+            // control directive; leave them to helper / section-name completion.
+            if (host.isPrintLike()) return
+
+            val caretInHost = ilm.injectedToHost(position, position.textRange.startOffset) - host.textRange.startOffset
+            if (!isDirectiveHead(host.text, caretInHost)) return
+
+            // Keywords are case-insensitive (PHP keyword / method semantics), like
+            // the built-in PHP completion.
+            val sink = result.caseInsensitive()
+            for (directive in DIRECTIVES) {
+                var element = LookupElementBuilder.create(directive.keyword).withTypeText("Qiq directive", true)
+                if (directive.call) element = element.withInsertHandler(CALL_INSERT_HANDLER)
+                sink.addElement(element)
+            }
+        }
+    }
+
+    /** A completable directive keyword. [call] directives are written `name(...)`. */
+    private data class Directive(val keyword: String, val call: Boolean)
+
+    companion object {
+        /**
+         * True when the caret sits at the directive head of a `{{ }}` block: only
+         * whitespace precedes it inside the block content ([caretInHost] is the
+         * caret offset within the host text). Pure, unit-tested.
+         */
+        fun isDirectiveHead(hostText: String, caretInHost: Int): Boolean =
+            caretInHost in 0..hostText.length && hostText.substring(0, caretInHost).isBlank()
+
+        // The directive vocabulary. Control directives (if/foreach/for + else/end*)
+        // are bare keywords; the template API (set/get/has Section, set/end Block,
+        // setLayout, extends) are call-style. Kept aligned with the opener/closer
+        // set in io.github.jingu.idea_qiq_plugin.block.QiqBlockType.
+        private val DIRECTIVES: List<Directive> = listOf(
+            Directive("if", call = false),
+            Directive("elseif", call = false),
+            Directive("else", call = false),
+            Directive("endif", call = false),
+            Directive("foreach", call = false),
+            Directive("endforeach", call = false),
+            Directive("for", call = false),
+            Directive("endfor", call = false),
+            Directive("setSection", call = true),
+            Directive("appendSection", call = true),
+            Directive("prependSection", call = true),
+            Directive("getSection", call = true),
+            Directive("hasSection", call = true),
+            Directive("endSection", call = true),
+            Directive("setBlock", call = true),
+            Directive("getBlock", call = true),
+            Directive("endBlock", call = true),
+            Directive("setLayout", call = true),
+            Directive("extends", call = true),
+        )
+
+        /** Keywords offered, for tests. */
+        val keywords: List<String> get() = DIRECTIVES.map { it.keyword }
+
+        // Append `()` and place the caret between the parens, unless a `(` already
+        // follows (re-completing an existing call). Mirrors QiqHelperCompletionContributor.
+        private val CALL_INSERT_HANDLER = InsertHandler<LookupElement> { context, _ ->
+            val document = context.document
+            val tailOffset = context.tailOffset
+            val alreadyHasParen = tailOffset < document.charsSequence.length &&
+                document.charsSequence[tailOffset] == '('
+            if (!alreadyHasParen) {
+                document.insertString(tailOffset, "()")
+            }
+            context.editor.caretModel.moveToOffset(tailOffset + 1)
+        }
+    }
+}

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/completion/QiqDirectiveCompletionContributor.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/completion/QiqDirectiveCompletionContributor.kt
@@ -20,10 +20,10 @@ import io.github.jingu.idea_qiq_plugin.psi.QiqCodeHost
  * the template API (`setSection`/`getSection`/`setLayout`/`extends`, ...).
  *
  * Fires only at the *head* of a non-print code block — where nothing but
- * whitespace precedes the caret inside the `{{ }}` — so keywords are not offered
- * mid-expression or inside `{{= }}` / `{{h }}` output tags (those already get
- * helper and section-name completion). Call-style directives insert with `()` and
- * the caret between the parens, mirroring [QiqHelperCompletionContributor].
+ * whitespace precedes the token being completed inside the `{{ }}` — so keywords
+ * are not offered mid-expression or inside `{{= }}` / `{{h }}` output tags (those
+ * already get helper and section-name completion). Call-style directives insert
+ * with `()` and the caret between the parens, mirroring [QiqHelperCompletionContributor].
  */
 class QiqDirectiveCompletionContributor : CompletionContributor() {
 
@@ -52,8 +52,13 @@ class QiqDirectiveCompletionContributor : CompletionContributor() {
             // control directive; leave them to helper / section-name completion.
             if (host.isPrintLike()) return
 
-            val caretInHost = ilm.injectedToHost(position, position.textRange.startOffset) - host.textRange.startOffset
-            if (!isDirectiveHead(host.text, caretInHost)) return
+            // Start offset of the directive token being completed, in host
+            // coordinates. We take the *start* of `position` (the typed prefix, or
+            // completion's synthetic dummy identifier when the head is still empty)
+            // rather than the live caret, so the head gate stays satisfied while a
+            // keyword is being typed.
+            val tokenStartInHost = ilm.injectedToHost(position, position.textRange.startOffset) - host.textRange.startOffset
+            if (!isDirectiveHead(host.text, tokenStartInHost)) return
 
             // Keywords are case-insensitive (PHP keyword / method semantics), like
             // the built-in PHP completion.
@@ -71,12 +76,14 @@ class QiqDirectiveCompletionContributor : CompletionContributor() {
 
     companion object {
         /**
-         * True when the caret sits at the directive head of a `{{ }}` block: only
-         * whitespace precedes it inside the block content ([caretInHost] is the
-         * caret offset within the host text). Pure, unit-tested.
+         * True when the directive token sits at the head of a `{{ }}` block: only
+         * whitespace precedes it inside the block content. [tokenStartInHost] is the
+         * start offset of that token within the host text — the typed prefix, or
+         * completion's synthetic dummy identifier when the head is still empty — not
+         * the live caret. Pure, unit-tested.
          */
-        fun isDirectiveHead(hostText: String, caretInHost: Int): Boolean =
-            caretInHost in 0..hostText.length && hostText.substring(0, caretInHost).isBlank()
+        fun isDirectiveHead(hostText: String, tokenStartInHost: Int): Boolean =
+            tokenStartInHost in 0..hostText.length && hostText.substring(0, tokenStartInHost).isBlank()
 
         // The directive vocabulary. Control directives (if/foreach/for + else/end*)
         // are bare keywords; the template API (set/get/has Section, set/end Block,

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/completion/QiqDirectiveCompletionContributor.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/completion/QiqDirectiveCompletionContributor.kt
@@ -82,8 +82,15 @@ class QiqDirectiveCompletionContributor : CompletionContributor() {
          * completion's synthetic dummy identifier when the head is still empty — not
          * the live caret. Pure, unit-tested.
          */
-        fun isDirectiveHead(hostText: String, tokenStartInHost: Int): Boolean =
-            tokenStartInHost in 0..hostText.length && hostText.substring(0, tokenStartInHost).isBlank()
+        fun isDirectiveHead(hostText: String, tokenStartInHost: Int): Boolean {
+            if (tokenStartInHost !in 0..hostText.length) return false
+            // Scan the prefix in place instead of allocating a substring; this is
+            // on the completion hot path.
+            for (i in 0 until tokenStartInHost) {
+                if (!hostText[i].isWhitespace()) return false
+            }
+            return true
+        }
 
         // The directive vocabulary. Control directives (if/foreach/for + else/end*)
         // are bare keywords; the template API (set/get/has Section, set/end Block,

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/liveTemplate/QiqLiveTemplateContextType.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/liveTemplate/QiqLiveTemplateContextType.kt
@@ -1,0 +1,24 @@
+package io.github.jingu.idea_qiq_plugin.liveTemplate
+
+import com.intellij.codeInsight.template.TemplateActionContext
+import com.intellij.codeInsight.template.TemplateContextType
+import io.github.jingu.idea_qiq_plugin.lang.QiqFileType
+import io.github.jingu.idea_qiq_plugin.lang.QiqTemplateLanguage
+
+/**
+ * Live-template context for Qiq templates: enables the bundled block snippets
+ * (`qif`, `qforeach`, `qsection`, ...) inside a `.qiq` / `.qiq.php` file.
+ *
+ * Registered with `contextId="QIQ"` in plugin.xml; the templates in
+ * `resources/liveTemplates/Qiq.xml` reference that id in their `<context>`.
+ */
+class QiqLiveTemplateContextType : TemplateContextType("Qiq") {
+
+    override fun isInContext(templateActionContext: TemplateActionContext): Boolean {
+        val file = templateActionContext.file
+        if (file.fileType == QiqFileType) return true
+        if (file.viewProvider.baseLanguage == QiqTemplateLanguage) return true
+        val name = file.viewProvider.virtualFile.name
+        return name.endsWith(".qiq", ignoreCase = true) || name.endsWith(".qiq.php", ignoreCase = true)
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -215,6 +215,21 @@
                 language="PHP"
                 implementationClass="io.github.jingu.idea_qiq_plugin.completion.QiqSectionNameCompletionContributor"/>
 
+        <!-- Complete Qiq directive keywords (if/foreach/for + else/end*, and the
+             setSection/getSection/setLayout/extends template API) at the head of a
+             plain {{ }} block. The directive content is injected PHP, so this is a
+             PHP completion contributor gated to the directive-head position. -->
+        <completion.contributor
+                language="PHP"
+                implementationClass="io.github.jingu.idea_qiq_plugin.completion.QiqDirectiveCompletionContributor"/>
+
+        <!-- Live Templates for Qiq blocks (qif / qforeach / qfor / qsection /
+             qblock / qlayout), available inside .qiq / .qiq.php files. -->
+        <liveTemplateContext
+                contextId="QIQ"
+                implementation="io.github.jingu.idea_qiq_plugin.liveTemplate.QiqLiveTemplateContextType"/>
+        <defaultLiveTemplates file="liveTemplates/Qiq"/>
+
         <!-- ElementManipulators: required for refactorings (Rename, Move, etc.)
              to propagate edits made inside the injected PHP back to the Qiq host. -->
         <lang.elementManipulator

--- a/src/main/resources/liveTemplates/Qiq.xml
+++ b/src/main/resources/liveTemplates/Qiq.xml
@@ -1,0 +1,41 @@
+<templateSet group="Qiq">
+  <template name="qif" value="{{ if ($EXPR$): }}&#10;$END$&#10;{{ endif }}" description="Qiq: if block" toReformat="false" toShortenFQNames="false">
+    <variable name="EXPR" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="QIQ" value="true" />
+    </context>
+  </template>
+  <template name="qforeach" value="{{ foreach ($ITEMS$ as $ITEM$): }}&#10;$END$&#10;{{ endforeach }}" description="Qiq: foreach block" toReformat="false" toShortenFQNames="false">
+    <variable name="ITEMS" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="ITEM" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="QIQ" value="true" />
+    </context>
+  </template>
+  <template name="qfor" value="{{ for ($INIT$; $COND$; $STEP$): }}&#10;$END$&#10;{{ endfor }}" description="Qiq: for block" toReformat="false" toShortenFQNames="false">
+    <variable name="INIT" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="COND" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="STEP" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="QIQ" value="true" />
+    </context>
+  </template>
+  <template name="qsection" value="{{ setSection('$NAME$') }}&#10;$END$&#10;{{ endSection() }}" description="Qiq: setSection block" toReformat="false" toShortenFQNames="false">
+    <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="QIQ" value="true" />
+    </context>
+  </template>
+  <template name="qblock" value="{{ setBlock('$NAME$') }}&#10;$END$&#10;{{ endBlock() }}" description="Qiq: setBlock block" toReformat="false" toShortenFQNames="false">
+    <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="QIQ" value="true" />
+    </context>
+  </template>
+  <template name="qlayout" value="{{ setLayout('$NAME$') }}$END$" description="Qiq: setLayout" toReformat="false" toShortenFQNames="false">
+    <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="QIQ" value="true" />
+    </context>
+  </template>
+</templateSet>

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/completion/QiqDirectiveCompletionContributorTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/completion/QiqDirectiveCompletionContributorTest.kt
@@ -1,0 +1,58 @@
+package io.github.jingu.idea_qiq_plugin.completion
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests the pure directive-head gate that decides where keyword completion fires.
+ * [hostText] is the `{{ }}` block content; [caretInHost] the caret offset within it.
+ */
+class QiqDirectiveCompletionContributorTest {
+
+    private fun isHead(hostText: String, caretInHost: Int) =
+        QiqDirectiveCompletionContributor.isDirectiveHead(hostText, caretInHost)
+
+    @Test
+    fun firesAtEmptyHead() {
+        // `{{ | }}` — caret right after the opening brace, nothing typed.
+        assertTrue(isHead("", 0))
+        assertTrue(isHead("  ", 2))
+    }
+
+    @Test
+    fun firesWhileTypingAKeyword() {
+        // `{{ if| }}` — the dummy identifier starts at offset 1 (after the space),
+        // so only the leading whitespace precedes the caret position.
+        assertTrue(isHead(" if", 1))
+        assertTrue(isHead("   foreach", 3))
+    }
+
+    @Test
+    fun doesNotFireMidExpression() {
+        // `{{ $x && if| }}` — non-whitespace precedes the caret: not a head.
+        assertFalse(isHead("\$x && if", 6))
+    }
+
+    @Test
+    fun doesNotFireAfterReceiver() {
+        // `{{ $this->set| }}` — the `$this->` qualifier precedes the caret.
+        assertFalse(isHead("\$this->set", 7))
+    }
+
+    @Test
+    fun toleratesOutOfRangeCaret() {
+        assertFalse(isHead("if", -1))
+        assertFalse(isHead("if", 3))
+    }
+
+    @Test
+    fun offersControlAndApiKeywords() {
+        val keywords = QiqDirectiveCompletionContributor.keywords
+        // Control directives and the section/layout API are all present.
+        assertTrue(keywords.containsAll(listOf("if", "foreach", "for", "else", "endif")))
+        assertTrue(keywords.containsAll(listOf("setSection", "getSection", "setLayout", "extends")))
+        // append/prepend section openers complete too (#50 vocabulary).
+        assertTrue(keywords.containsAll(listOf("appendSection", "prependSection")))
+    }
+}

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/completion/QiqDirectiveCompletionContributorTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/completion/QiqDirectiveCompletionContributorTest.kt
@@ -6,42 +6,45 @@ import kotlin.test.assertTrue
 
 /**
  * Tests the pure directive-head gate that decides where keyword completion fires.
- * [hostText] is the `{{ }}` block content; [caretInHost] the caret offset within it.
+ * [hostText] is the `{{ }}` block content; [tokenStartInHost] is the start offset
+ * of the directive token being completed within it (the typed prefix, or
+ * completion's synthetic dummy identifier when the head is still empty) — not the
+ * live caret.
  */
 class QiqDirectiveCompletionContributorTest {
 
-    private fun isHead(hostText: String, caretInHost: Int) =
-        QiqDirectiveCompletionContributor.isDirectiveHead(hostText, caretInHost)
+    private fun isHead(hostText: String, tokenStartInHost: Int) =
+        QiqDirectiveCompletionContributor.isDirectiveHead(hostText, tokenStartInHost)
 
     @Test
     fun firesAtEmptyHead() {
-        // `{{ | }}` — caret right after the opening brace, nothing typed.
+        // `{{ | }}` — nothing typed; completion's dummy identifier sits at the head.
         assertTrue(isHead("", 0))
         assertTrue(isHead("  ", 2))
     }
 
     @Test
     fun firesWhileTypingAKeyword() {
-        // `{{ if| }}` — the dummy identifier starts at offset 1 (after the space),
-        // so only the leading whitespace precedes the caret position.
+        // `{{ if| }}` — the typed token starts at offset 1 (after the space), so
+        // only the leading whitespace precedes the token start.
         assertTrue(isHead(" if", 1))
         assertTrue(isHead("   foreach", 3))
     }
 
     @Test
     fun doesNotFireMidExpression() {
-        // `{{ $x && if| }}` — non-whitespace precedes the caret: not a head.
+        // `{{ $x && if| }}` — non-whitespace precedes the token start: not a head.
         assertFalse(isHead("\$x && if", 6))
     }
 
     @Test
     fun doesNotFireAfterReceiver() {
-        // `{{ $this->set| }}` — the `$this->` qualifier precedes the caret.
+        // `{{ $this->set| }}` — the `$this->` qualifier precedes the token start.
         assertFalse(isHead("\$this->set", 7))
     }
 
     @Test
-    fun toleratesOutOfRangeCaret() {
+    fun toleratesOutOfRangeToken() {
         assertFalse(isHead("if", -1))
         assertFalse(isHead("if", 3))
     }


### PR DESCRIPTION
## Summary

Adds the two template-language-native editor affordances tracked in #34, both verified manually in PhpStorm.

### 1. Directive keyword completion

At the **head of a plain `{{ }}` block**, completes:
- Control directives: `if` / `elseif` / `else` / `endif` / `foreach` / `endforeach` / `for` / `endfor`
- Template API: `setSection` / `appendSection` / `prependSection` / `getSection` / `hasSection` / `endSection` / `setBlock` / `getBlock` / `endBlock` / `setLayout` / `extends`

The `{{ }}` content is injected PHP, so this is a PHP `completion.contributor` gated to the **directive-head position** — only whitespace precedes the caret inside the host. That keeps keywords out of mid-expression positions and out of output tags (`{{= }}` / `{{h }}`, which already get helper and section-name completion). Call-style directives insert with `()` and place the caret between the parens, mirroring `QiqHelperCompletionContributor`.

The head-position check is a pure, unit-tested function (`isDirectiveHead`); the keyword vocabulary stays aligned with the opener/closer set in `QiqBlockType`.

### 2. Live Templates

`QiqLiveTemplateContextType` (context id `QIQ`, active in `.qiq` / `.qiq.php`) plus `resources/liveTemplates/Qiq.xml`:

| Abbrev | Expands to |
|---|---|
| `qif` | `{{ if (…): }}` … `{{ endif }}` |
| `qforeach` | `{{ foreach (… as …): }}` … `{{ endforeach }}` |
| `qfor` | `{{ for (…; …; …): }}` … `{{ endfor }}` |
| `qsection` | `{{ setSection('…') }}` … `{{ endSection() }}` |
| `qblock` | `{{ setBlock('…') }}` … `{{ endBlock() }}` |
| `qlayout` | `{{ setLayout('…') }}` |

## Tests

- `QiqDirectiveCompletionContributorTest`: the directive-head gate (fires at empty head / while typing a keyword; not mid-expression / after a `$this->` receiver / out of range) and the offered vocabulary.
- Full suite green; manually verified in PhpStorm (completion fires only at the directive head, snippets expand with tab-stops, the **Qiq** Live Templates group appears in Settings).

Closes #34. Part of the 1.0 roadmap epic #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)