### PR TITLE
test: HeavyPlatformTestCase fixture coverage for 1.0 (#32)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,8 +29,12 @@ dependencies {
         testFramework(TestFrameworkType.JUnit5)
     }
     testImplementation(kotlin("test"))
+    // BasePlatformTestCase / HeavyPlatformTestCase derive from JUnit3's TestCase, so
+    // JUnit4 must be on the compile classpath and the vintage engine present to run
+    // them under useJUnitPlatform() alongside the JUnit5 unit tests.
+    testImplementation("junit:junit:4.13.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
-    testRuntimeOnly("junit:junit:4.13.2")
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
 }
 
 val intellijTestDependencies = configurations.named("intellijPlatformTestDependencies")
@@ -106,4 +110,9 @@ kotlin {
 
 tasks.test {
     useJUnitPlatform()
+    // Fixture tests (BasePlatformTestCase) share an Application; the platform's
+    // leaked-project hunter can flag a still-watched light project when those
+    // classes run alongside the JUnit5 unit classes. Forking a fresh JVM per test
+    // class isolates each so the hunter only ever sees one suite's projects.
+    setForkEvery(1)
 }

--- a/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inspection/QiqHelperArgumentsInspection.kt
+++ b/src/main/kotlin/io/github/jingu/idea_qiq_plugin/inspection/QiqHelperArgumentsInspection.kt
@@ -9,7 +9,6 @@ import com.jetbrains.php.lang.psi.elements.Function
 import com.jetbrains.php.lang.psi.elements.FunctionReference
 import com.jetbrains.php.lang.psi.elements.MethodReference
 import com.jetbrains.php.lang.psi.elements.Parameter
-import com.jetbrains.php.lang.psi.elements.ParameterList
 import com.jetbrains.php.lang.psi.elements.PhpTypedElement
 import com.jetbrains.php.lang.psi.resolve.types.PhpType
 import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor
@@ -65,7 +64,7 @@ class QiqHelperArgumentsInspection : LocalInspectionTool() {
         if (hasUncountableArgument(parameterList.text)) return
 
         val args = parameterList.parameters
-        if (checkArgumentCount(name, args.size, targets, parameterList, holder)) return
+        if (checkArgumentCount(name, args.size, targets, call, holder)) return
 
         // Type-check only against a single unambiguous target.
         targets.singleOrNull()?.let { checkArgumentTypes(name, args, it, call.project, holder) }
@@ -76,7 +75,7 @@ class QiqHelperArgumentsInspection : LocalInspectionTool() {
         name: String,
         argCount: Int,
         targets: List<Function>,
-        parameterList: ParameterList,
+        call: FunctionReference,
         holder: ProblemsHolder,
     ): Boolean {
         // Valid as soon as one target accepts the count. Checking per target (not
@@ -96,7 +95,11 @@ class QiqHelperArgumentsInspection : LocalInspectionTool() {
                 // global window, so neither "too few" nor "too many" fits.
                 QiqBundle.message("inspection.helper.argcount.invalid", name, argCount)
         }
-        holder.registerProblem(parameterList, message)
+        // Anchor on the argument list, but fall back to the whole call when it is
+        // empty (`name()`): an empty `()` parameter list has a zero-width range,
+        // which registerProblem rejects.
+        val anchor: PsiElement = call.parameterList?.takeUnless { it.textRange.isEmpty } ?: call
+        holder.registerProblem(anchor, message)
         return true
     }
 

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqBlockDirectiveInspectionFixtureTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqBlockDirectiveInspectionFixtureTest.kt
@@ -1,0 +1,46 @@
+package io.github.jingu.idea_qiq_plugin.fixture
+
+import com.intellij.codeInsight.daemon.impl.HighlightInfo
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import io.github.jingu.idea_qiq_plugin.inspection.QiqBlockDirectiveInspection
+
+/**
+ * Integration coverage for [QiqBlockDirectiveInspection]: drives the real platform
+ * highlighting pipeline (registration + PSI + the shared [QiqBlockModel] validator)
+ * rather than the pure validator alone (QiqBlockModelTest). #30 / #32.
+ */
+class QiqBlockDirectiveInspectionFixtureTest : BasePlatformTestCase() {
+
+    private fun qiqWarnings(text: String): List<HighlightInfo> {
+        myFixture.configureByText("page.qiq", text)
+        myFixture.enableInspections(QiqBlockDirectiveInspection())
+        return myFixture.doHighlighting(HighlightSeverity.WARNING)
+            .filter { it.description?.contains("Qiq") == true }
+    }
+
+    fun testBalancedBlockHasNoWarning() {
+        val warnings = qiqWarnings("{{ if (\$x): }}\n<p>ok</p>\n{{ endif }}")
+        assertEmpty(warnings)
+    }
+
+    fun testUnclosedOpenerIsFlagged() {
+        val warnings = qiqWarnings("{{ if (\$x): }}\n<p>oops</p>")
+        assertSize(1, warnings)
+        assertTrue(warnings[0].description, warnings[0].description.contains("Unclosed Qiq block"))
+    }
+
+    fun testUnmatchedCloserIsFlagged() {
+        val warnings = qiqWarnings("<p>oops</p>\n{{ endif }}")
+        assertSize(1, warnings)
+        assertTrue(warnings[0].description, warnings[0].description.contains("no matching opener"))
+    }
+
+    fun testMismatchedCloserIsFlagged() {
+        val warnings = qiqWarnings("{{ foreach (\$xs as \$x): }}\n{{ endif }}")
+        assertTrue(
+            "expected a mismatch/unclosed warning, got: ${warnings.map { it.description }}",
+            warnings.any { it.description.contains("does not match") },
+        )
+    }
+}

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqBlockPairHighlightFixtureTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqBlockPairHighlightFixtureTest.kt
@@ -15,7 +15,9 @@ class QiqBlockPairHighlightFixtureTest : BasePlatformTestCase() {
 
     private fun usagesWithCaretOn(token: String): List<String> {
         myFixture.configureByText("page.qiq", source)
-        myFixture.editor.caretModel.moveToOffset(source.indexOf(token) + 3)
+        val tokenIndex = source.indexOf(token)
+        assertTrue("token '$token' not found in source", tokenIndex >= 0)
+        myFixture.editor.caretModel.moveToOffset(tokenIndex + 3)
         val target = myFixture.file.findElementAt(myFixture.editor.caretModel.offset)
             ?: error("no element at caret")
         val handler = QiqBlockPairHighlightUsagesHandlerFactory()

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqBlockPairHighlightFixtureTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqBlockPairHighlightFixtureTest.kt
@@ -1,0 +1,41 @@
+package io.github.jingu.idea_qiq_plugin.fixture
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import io.github.jingu.idea_qiq_plugin.editor.QiqBlockPairHighlightUsagesHandlerFactory
+
+/**
+ * Integration coverage for QiqBlockPairHighlightUsagesHandlerFactory (#28 / #32):
+ * with the caret on a block opener or closer, the handler highlights both the
+ * opener and the closer delimiters.
+ */
+class QiqBlockPairHighlightFixtureTest : BasePlatformTestCase() {
+
+    private val source = "{{ if (\$x): }}\n<p>a</p>\n{{ endif }}"
+
+    private fun usagesWithCaretOn(token: String): List<String> {
+        myFixture.configureByText("page.qiq", source)
+        myFixture.editor.caretModel.moveToOffset(source.indexOf(token) + 3)
+        val target = myFixture.file.findElementAt(myFixture.editor.caretModel.offset)
+            ?: error("no element at caret")
+        val handler = QiqBlockPairHighlightUsagesHandlerFactory()
+            .createHighlightUsagesHandler(myFixture.editor, myFixture.file, target)
+            ?: error("no block-pair highlight handler at caret")
+        handler.highlightUsages()
+        return handler.readUsages.map { r: TextRange -> source.substring(r.startOffset, r.endOffset) }
+    }
+
+    fun testCaretOnOpenerHighlightsBothDelimiters() {
+        val texts = usagesWithCaretOn("{{ if")
+        assertSize(2, texts)
+        assertTrue(texts.toString(), texts.any { it.startsWith("{{ if") })
+        assertTrue(texts.toString(), texts.any { it.startsWith("{{ endif") })
+    }
+
+    fun testCaretOnCloserHighlightsBothDelimiters() {
+        val texts = usagesWithCaretOn("{{ endif")
+        assertSize(2, texts)
+        assertTrue(texts.toString(), texts.any { it.startsWith("{{ if") })
+        assertTrue(texts.toString(), texts.any { it.startsWith("{{ endif") })
+    }
+}

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqDirectiveCompletionFixtureTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqDirectiveCompletionFixtureTest.kt
@@ -1,0 +1,34 @@
+package io.github.jingu.idea_qiq_plugin.fixture
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+/**
+ * Integration coverage for QiqDirectiveCompletionContributor (#34 / #32): drives
+ * real completion (dummy-identifier + PHP injection) at and away from the directive
+ * head, complementing the pure head-gate unit tests.
+ */
+class QiqDirectiveCompletionFixtureTest : BasePlatformTestCase() {
+
+    private fun completionAt(text: String): List<String> {
+        myFixture.configureByText("page.qiq", text)
+        myFixture.completeBasic()
+        return myFixture.lookupElementStrings ?: emptyList()
+    }
+
+    fun testDirectiveHeadOffersControlAndApiKeywords() {
+        val items = completionAt("{{ <caret> }}")
+        assertContainsElements(items, "if", "foreach", "for", "setSection", "setLayout")
+    }
+
+    fun testWhileTypingFiltersToMatchingDirective() {
+        val items = completionAt("{{ fore<caret> }}")
+        assertContainsElements(items, "foreach")
+    }
+
+    fun testOutputTagDoesNotOfferControlDirectives() {
+        // Inside `{{= }}` the head is an expression, so the control keywords that
+        // only make sense as a directive head must not be offered.
+        val items = completionAt("{{= <caret> }}")
+        assertDoesntContain(items, "endif", "endforeach")
+    }
+}

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqFixtureSmokeTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqFixtureSmokeTest.kt
@@ -1,0 +1,34 @@
+package io.github.jingu.idea_qiq_plugin.fixture
+
+import com.intellij.lang.injection.InjectedLanguageManager
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.jetbrains.php.lang.PhpLanguage
+import io.github.jingu.idea_qiq_plugin.lang.QiqFileType
+import io.github.jingu.idea_qiq_plugin.psi.QiqCodeHost
+
+/**
+ * Smoke test proving the fixture harness boots with the Qiq language and the
+ * bundled PHP plugin, and that PHP is injected into a `{{ ... }}` host. The
+ * feature-specific HeavyPlatformTestCase suites (#32) build on this setup.
+ */
+class QiqFixtureSmokeTest : BasePlatformTestCase() {
+
+    fun testQiqFileTypeRecognized() {
+        val file = myFixture.configureByText("page.qiq", "<div>{{= \$x }}</div>")
+        assertEquals(QiqFileType, file.fileType)
+    }
+
+    fun testPhpInjectedIntoCodeHost() {
+        val file = myFixture.configureByText("page.qiq", "{{= 1 + 2 }}")
+        val host = PsiTreeUtil.findChildOfType(file, QiqCodeHost::class.java)
+        assertNotNull("expected a Qiq code host", host)
+
+        val injected = mutableListOf<PsiFile>()
+        InjectedLanguageManager.getInstance(project)
+            .enumerate(host!!) { injectedPsi, _ -> injected.add(injectedPsi) }
+        assertTrue("expected PHP injected into the {{= }} host", injected.isNotEmpty())
+        assertEquals(PhpLanguage.INSTANCE, injected.first().language)
+    }
+}

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqFoldingFixtureTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqFoldingFixtureTest.kt
@@ -1,0 +1,34 @@
+package io.github.jingu.idea_qiq_plugin.fixture
+
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import io.github.jingu.idea_qiq_plugin.editor.QiqFoldingBuilder
+
+/**
+ * Integration coverage for QiqFoldingBuilder (#27 / #32): runs the real builder over
+ * the parsed Qiq PSI/document. We call the builder directly rather than reading the
+ * editor's fold regions, which would also include HTML / injected-PHP folds.
+ */
+class QiqFoldingFixtureTest : BasePlatformTestCase() {
+
+    private fun descriptors(text: String): List<FoldingDescriptor> {
+        val file = myFixture.configureByText("page.qiq", text)
+        return QiqFoldingBuilder().buildFoldRegions(file, myFixture.editor.document, false).toList()
+    }
+
+    fun testMultiLineBlockFolds() {
+        val d = descriptors("{{ if (\$x): }}\n<p>a</p>\n<p>b</p>\n{{ endif }}")
+        assertSize(1, d)
+        assertEquals("…", QiqFoldingBuilder().getPlaceholderText(d.first().element))
+    }
+
+    fun testSingleLineBlockDoesNotFold() {
+        // Opener and closer on one line: nothing to collapse.
+        assertEmpty(descriptors("{{ if (\$x): }}{{ endif }}"))
+    }
+
+    fun testNestedBlocksProduceTwoRegions() {
+        val text = "{{ foreach (\$xs as \$x): }}\n{{ if (\$x): }}\n<p>a</p>\n{{ endif }}\n{{ endforeach }}"
+        assertSize(2, descriptors(text))
+    }
+}

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqHelperArgumentsInspectionFixtureTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqHelperArgumentsInspectionFixtureTest.kt
@@ -1,0 +1,45 @@
+package io.github.jingu.idea_qiq_plugin.fixture
+
+import com.intellij.codeInsight.daemon.impl.HighlightInfo
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import io.github.jingu.idea_qiq_plugin.inspection.QiqHelperArgumentsInspection
+import io.github.jingu.idea_qiq_plugin.settings.QiqSettingsService
+
+/**
+ * Integration coverage for [QiqHelperArgumentsInspection] (#32): checks helper call
+ * arity and argument types against the resolved __invoke signature. Exercises the
+ * bootstrap scan + PhpIndex class resolution + injected-PHP inspection.
+ */
+class QiqHelperArgumentsInspectionFixtureTest : BasePlatformTestCase() {
+
+    private fun helperWarnings(callBody: String): List<HighlightInfo> {
+        myFixture.addFileToProject(
+            "GreetHelper.php",
+            "<?php\nclass GreetHelper {\n    public function __invoke(string \$name): string { return \$name; }\n}\n",
+        )
+        myFixture.addFileToProject(
+            "bootstrap.php",
+            "<?php\n\$helpers->set('greet', fn() => new GreetHelper());\n",
+        )
+        QiqSettingsService.getInstance(project).setHelperBootstrapFiles(listOf("bootstrap.php"))
+        myFixture.configureByText("page.qiq", callBody)
+        myFixture.enableInspections(QiqHelperArgumentsInspection())
+        return myFixture.doHighlighting(HighlightSeverity.WARNING)
+            .filter { it.description?.contains("helper") == true }
+    }
+
+    fun testCorrectCallNotFlagged() {
+        assertEmpty(helperWarnings("{{ greet('world') }}"))
+    }
+
+    fun testTooFewArgumentsFlagged() {
+        val warnings = helperWarnings("{{ greet() }}")
+        assertTrue(warnings.toString(), warnings.any { it.description.contains("Too few") })
+    }
+
+    fun testArgumentTypeMismatchFlagged() {
+        val warnings = helperWarnings("{{ greet([1, 2]) }}")
+        assertTrue(warnings.toString(), warnings.any { it.description.contains("expected") })
+    }
+}

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqHelperCompletionFixtureTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqHelperCompletionFixtureTest.kt
@@ -1,0 +1,43 @@
+package io.github.jingu.idea_qiq_plugin.fixture
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import io.github.jingu.idea_qiq_plugin.helper.QiqHelperRegistry
+import io.github.jingu.idea_qiq_plugin.settings.QiqSettingsService
+
+/**
+ * Integration coverage for QiqHelperCompletionContributor (#32): a helper
+ * registered in a nominated bootstrap file is offered at a `{{ name(...) }}` call
+ * position. Exercises the real bootstrap scan + settings + PHP injection.
+ */
+class QiqHelperCompletionFixtureTest : BasePlatformTestCase() {
+
+    private fun setUpHelper() {
+        myFixture.addFileToProject(
+            "GreetHelper.php",
+            "<?php\nclass GreetHelper {\n    public function __invoke(\$name) { return \$name; }\n}\n",
+        )
+        myFixture.addFileToProject(
+            "bootstrap.php",
+            "<?php\n\$helpers->set('greet', fn() => new GreetHelper());\n" +
+                "\$helpers->set('greeting', fn() => new GreetHelper());\n",
+        )
+        QiqSettingsService.getInstance(project).setHelperBootstrapFiles(listOf("bootstrap.php"))
+    }
+
+    fun testRegistryDiscoversHelper() {
+        setUpHelper()
+        val names = QiqHelperRegistry.getInstance(project).allHelperNames()
+        assertContainsElements(names, "greet", "greeting")
+    }
+
+    fun testRegisteredHelperOffered() {
+        setUpHelper()
+        // Two helpers share the `gree` prefix so the popup stays open (a single
+        // match would auto-insert and leave no lookup to inspect); the `()` makes
+        // it a call-name position.
+        myFixture.configureByText("page.qiq", "{{ gree<caret>() }}")
+        myFixture.completeBasic()
+        val items = myFixture.lookupElementStrings ?: emptyList()
+        assertContainsElements(items, "greet", "greeting")
+    }
+}

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqHelperDocumentationFixtureTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqHelperDocumentationFixtureTest.kt
@@ -1,0 +1,44 @@
+package io.github.jingu.idea_qiq_plugin.fixture
+
+import com.intellij.lang.injection.InjectedLanguageManager
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.jetbrains.php.lang.psi.elements.Function
+import com.jetbrains.php.lang.psi.elements.FunctionReference
+import io.github.jingu.idea_qiq_plugin.navigation.QiqHelperDocumentationProvider
+import io.github.jingu.idea_qiq_plugin.psi.QiqCodeHost
+import io.github.jingu.idea_qiq_plugin.settings.QiqSettingsService
+
+/**
+ * Integration coverage for QiqHelperDocumentationProvider (#32): Quick Doc on a
+ * helper call points at the resolved helper target (the class's __invoke) rather
+ * than the unresolved injected global call.
+ */
+class QiqHelperDocumentationFixtureTest : BasePlatformTestCase() {
+
+    fun testDocResolvesToHelperInvoke() {
+        myFixture.addFileToProject(
+            "GreetHelper.php",
+            "<?php\nclass GreetHelper {\n    /** Greet someone. */\n    public function __invoke(string \$name): string { return \$name; }\n}\n",
+        )
+        myFixture.addFileToProject("bootstrap.php", "<?php\n\$helpers->set('greet', fn() => new GreetHelper());\n")
+        QiqSettingsService.getInstance(project).setHelperBootstrapFiles(listOf("bootstrap.php"))
+        val file = myFixture.configureByText("page.qiq", "{{ greet('x') }}")
+
+        val host = PsiTreeUtil.findChildOfType(file, QiqCodeHost::class.java) ?: error("no code host")
+        var injected: PsiFile? = null
+        InjectedLanguageManager.getInstance(project).enumerate(host) { f, _ -> injected = f }
+        val injectedFile = injected ?: error("no injected PHP")
+        val call = PsiTreeUtil.findChildrenOfType(injectedFile, FunctionReference::class.java)
+            .first { it.name == "greet" }
+        val nameLeaf = call.nameNode?.psi ?: error("no name node")
+
+        val target = QiqHelperDocumentationProvider()
+            .getCustomDocumentationElement(myFixture.editor, injectedFile, nameLeaf, 0)
+
+        assertNotNull("expected the helper doc to resolve to a target", target)
+        assertEquals("__invoke", (target as? Function)?.name)
+        assertEquals("GreetHelper", (target as? com.jetbrains.php.lang.psi.elements.Method)?.containingClass?.name)
+    }
+}

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqHelperParameterInfoFixtureTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqHelperParameterInfoFixtureTest.kt
@@ -1,0 +1,32 @@
+package io.github.jingu.idea_qiq_plugin.fixture
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.testFramework.utils.parameterInfo.MockParameterInfoUIContext
+import io.github.jingu.idea_qiq_plugin.helper.QiqHelperTargets
+import io.github.jingu.idea_qiq_plugin.navigation.QiqHelperParameterInfoHandler
+import io.github.jingu.idea_qiq_plugin.settings.QiqSettingsService
+
+/**
+ * Integration coverage for QiqHelperParameterInfoHandler (#32): the resolved helper
+ * __invoke signature is rendered for a helper call. Exercises the bootstrap scan +
+ * PhpIndex resolution feeding the parameter-info UI.
+ */
+class QiqHelperParameterInfoFixtureTest : BasePlatformTestCase() {
+
+    fun testRendersResolvedInvokeSignature() {
+        myFixture.addFileToProject(
+            "GreetHelper.php",
+            "<?php\nclass GreetHelper {\n    public function __invoke(string \$name): string { return \$name; }\n}\n",
+        )
+        myFixture.addFileToProject("bootstrap.php", "<?php\n\$helpers->set('greet', fn() => new GreetHelper());\n")
+        QiqSettingsService.getInstance(project).setHelperBootstrapFiles(listOf("bootstrap.php"))
+        val file = myFixture.configureByText("page.qiq", "{{ greet('x') }}")
+
+        val invoke = QiqHelperTargets.functions(project, "greet").firstOrNull()
+            ?: error("helper 'greet' did not resolve to a target")
+        val context = MockParameterInfoUIContext(file)
+        QiqHelperParameterInfoHandler().updateUI(invoke, context)
+
+        assertTrue("signature should mention the parameter, was: ${context.text}", context.text.contains("name"))
+    }
+}

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqSectionNameCompletionFixtureTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqSectionNameCompletionFixtureTest.kt
@@ -24,7 +24,9 @@ class QiqSectionNameCompletionFixtureTest : BasePlatformTestCase() {
         )
         myFixture.configureFromExistingVirtualFile(layout.virtualFile)
         // addFileToProject keeps `<caret>` literal, so place the caret in the quotes.
-        myFixture.editor.caretModel.moveToOffset(layout.text.indexOf(marker) + marker.length)
+        val markerIndex = layout.text.indexOf(marker)
+        assertTrue("marker '$marker' not found in fixture text", markerIndex >= 0)
+        myFixture.editor.caretModel.moveToOffset(markerIndex + marker.length)
         myFixture.completeBasic()
 
         val items = myFixture.lookupElementStrings ?: emptyList()

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqSectionNameCompletionFixtureTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqSectionNameCompletionFixtureTest.kt
@@ -1,0 +1,33 @@
+package io.github.jingu.idea_qiq_plugin.fixture
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+/**
+ * Integration coverage for QiqSectionNameCompletionContributor (#31 / #32):
+ * getSection('<caret>') offers the section names defined by setSection across the
+ * template roots.
+ */
+class QiqSectionNameCompletionFixtureTest : BasePlatformTestCase() {
+
+    fun testCompletesDefinedSectionNames() {
+        val root = "qiq_${getTestName(true)}"
+        myFixture.addFileToProject(
+            "$root/template/page/home.qiq.php",
+            "{{ setSection('content') }}<p>hi</p>{{ endSection() }}" +
+                "{{ setSection('sidebar') }}<aside>s</aside>{{ endSection() }}",
+        )
+        myFixture.addFileToProject("$root/helper/Foo.php", "<?php\nclass Foo {}\n")
+        val marker = "getSection('"
+        val layout = myFixture.addFileToProject(
+            "$root/template/layout/base.qiq.php",
+            "<html>{{= \$this->$marker') }}{{ if (\$y): }}<i>y</i>{{ endif }}</html>",
+        )
+        myFixture.configureFromExistingVirtualFile(layout.virtualFile)
+        // addFileToProject keeps `<caret>` literal, so place the caret in the quotes.
+        myFixture.editor.caretModel.moveToOffset(layout.text.indexOf(marker) + marker.length)
+        myFixture.completeBasic()
+
+        val items = myFixture.lookupElementStrings ?: emptyList()
+        assertContainsElements(items, "content", "sidebar")
+    }
+}

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqSectionNameInspectionFixtureTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqSectionNameInspectionFixtureTest.kt
@@ -1,0 +1,43 @@
+package io.github.jingu.idea_qiq_plugin.fixture
+
+import com.intellij.codeInsight.daemon.impl.HighlightInfo
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import io.github.jingu.idea_qiq_plugin.inspection.QiqSectionNameInspection
+
+/**
+ * Integration coverage for [QiqSectionNameInspection] (#31 / #32): a getSection()
+ * for a name some template defines is clean; one no template defines is flagged.
+ * Exercises the real cross-template section index over the qiq/{template,helper}
+ * layout.
+ */
+class QiqSectionNameInspectionFixtureTest : BasePlatformTestCase() {
+
+    private fun undefinedWarnings(layoutBody: String): List<HighlightInfo> {
+        // Unique tree per method (the light project's root cache is reused).
+        val root = "qiq_${getTestName(true)}"
+        myFixture.addFileToProject(
+            "$root/template/page/home.qiq.php",
+            "{{ setSection('content') }}<p>hi</p>{{ endSection() }}{{ if (\$x): }}<i>x</i>{{ endif }}",
+        )
+        myFixture.addFileToProject("$root/helper/Foo.php", "<?php\nclass Foo {}\n")
+        val layout = myFixture.addFileToProject("$root/template/layout/base.qiq.php", layoutBody)
+        myFixture.configureFromExistingVirtualFile(layout.virtualFile)
+        myFixture.enableInspections(QiqSectionNameInspection())
+        return myFixture.doHighlighting(HighlightSeverity.WARNING)
+            .filter { it.description?.contains("is not defined") == true }
+    }
+
+    fun testDefinedSectionNotFlagged() {
+        assertEmpty(
+            undefinedWarnings("<html>{{= \$this->getSection('content') }}{{ if (\$y): }}<b>y</b>{{ endif }}</html>"),
+        )
+    }
+
+    fun testUndefinedSectionFlagged() {
+        val warnings =
+            undefinedWarnings("<html>{{= \$this->getSection('missing') }}{{ if (\$y): }}<b>y</b>{{ endif }}</html>")
+        assertSize(1, warnings)
+        assertTrue(warnings[0].description, warnings[0].description.contains("missing"))
+    }
+}

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqStructureViewFixtureTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqStructureViewFixtureTest.kt
@@ -1,0 +1,40 @@
+package io.github.jingu.idea_qiq_plugin.fixture
+
+import com.intellij.testFramework.PlatformTestUtil
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+/**
+ * Integration coverage for QiqStructureViewFactory (#29 / #32): builds the real
+ * structure view through the registered factory and checks the rendered tree,
+ * complementing the pure QiqOutline tests.
+ */
+class QiqStructureViewFixtureTest : BasePlatformTestCase() {
+
+    private fun renderedStructure(text: String): String {
+        myFixture.configureByText("page.qiq", text)
+        var rendered = ""
+        myFixture.testStructureView { component ->
+            PlatformTestUtil.expandAll(component.tree)
+            rendered = PlatformTestUtil.print(component.tree, false)
+        }
+        return rendered
+    }
+
+    fun testSectionAndControlBlockOutline() {
+        val text = """
+            {{ setSection('content') }}
+            {{ if (${'$'}x): }}
+            <p>hi</p>
+            {{ endif }}
+            {{ endSection() }}
+        """.trimIndent()
+        val rendered = renderedStructure(text)
+        assertTrue(rendered, rendered.contains("section 'content'"))
+        assertTrue(rendered, rendered.contains("if (${'$'}x)"))
+    }
+
+    fun testLayoutDirectiveAppearsAtTopLevel() {
+        val rendered = renderedStructure("{{ setLayout('layout/base') }}\n<p>body</p>")
+        assertTrue(rendered, rendered.contains("setLayout('layout/base')"))
+    }
+}

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqTemplateBaseResolutionFixtureTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqTemplateBaseResolutionFixtureTest.kt
@@ -1,0 +1,34 @@
+package io.github.jingu.idea_qiq_plugin.fixture
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import io.github.jingu.idea_qiq_plugin.settings.QiqSettingsService
+
+/**
+ * Integration coverage for QiqSettingsService.resolveTemplateBase (#32): the base
+ * for a file under a `qiq/{template,helper}` tree is the `template/` directory —
+ * the root a Qiq `/...` root-absolute path is resolved against — not `qiq/`.
+ */
+class QiqTemplateBaseResolutionFixtureTest : BasePlatformTestCase() {
+
+    fun testBaseStopsAtTemplateDirectory() {
+        val root = "qiq_${getTestName(true)}"
+        myFixture.addFileToProject(
+            "$root/template/layout/base.qiq.php",
+            "<html>{{= \$this->getSection('content') }}{{ if (\$x): }}<i>x</i>{{ endif }}</html>",
+        )
+        myFixture.addFileToProject(
+            "$root/template/partial/menu.qiq.php",
+            "<ul>{{ foreach (\$items as \$i): }}<li>{{= \$i }}</li>{{ endforeach }}</ul>",
+        )
+        // A non-template sibling (plain PHP) marks the edge of the template tree.
+        myFixture.addFileToProject("$root/helper/Foo.php", "<?php\nclass Foo {}\n")
+        val home = myFixture.addFileToProject(
+            "$root/template/page/home.qiq.php",
+            "{{ setSection('content') }}<p>hi</p>{{ endSection() }}{{ if (\$y): }}<b>y</b>{{ endif }}",
+        )
+
+        val base = QiqSettingsService.getInstance(project).resolveTemplateBase(home.virtualFile)
+        assertNotNull("expected a template base directory", base)
+        assertEquals("template", base!!.name)
+    }
+}

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqTemplatePathCompletionFixtureTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqTemplatePathCompletionFixtureTest.kt
@@ -22,7 +22,9 @@ class QiqTemplatePathCompletionFixtureTest : BasePlatformTestCase() {
         myFixture.addFileToProject("$root/helper/Foo.php", "<?php\nclass Foo {}\n")
         val home = myFixture.addFileToProject("$root/template/page/home.qiq.php", homeBody)
         myFixture.configureFromExistingVirtualFile(home.virtualFile)
-        myFixture.editor.caretModel.moveToOffset(home.text.indexOf(marker) + marker.length)
+        val markerIndex = home.text.indexOf(marker)
+        assertTrue("marker '$marker' not found in fixture text", markerIndex >= 0)
+        myFixture.editor.caretModel.moveToOffset(markerIndex + marker.length)
         myFixture.completeBasic()
         return myFixture.lookupElementStrings ?: emptyList()
     }

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqTemplatePathCompletionFixtureTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqTemplatePathCompletionFixtureTest.kt
@@ -1,0 +1,46 @@
+package io.github.jingu.idea_qiq_plugin.fixture
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+/**
+ * Integration coverage for QiqTemplatePathCompletionContributor (#32): render()
+ * offers the template paths discovered under the roots, both relative and
+ * root-absolute (`/`-prefixed).
+ */
+class QiqTemplatePathCompletionFixtureTest : BasePlatformTestCase() {
+
+    private fun completionInside(homeBody: String, marker: String): List<String> {
+        val root = "qiq_${getTestName(true)}"
+        myFixture.addFileToProject(
+            "$root/template/layout/base.qiq.php",
+            "<html>{{= \$this->getSection('content') }}{{ if (\$x): }}<i>x</i>{{ endif }}</html>",
+        )
+        myFixture.addFileToProject(
+            "$root/template/partial/menu.qiq.php",
+            "<ul>{{ foreach (\$items as \$i): }}<li>{{= \$i }}</li>{{ endforeach }}</ul>",
+        )
+        myFixture.addFileToProject("$root/helper/Foo.php", "<?php\nclass Foo {}\n")
+        val home = myFixture.addFileToProject("$root/template/page/home.qiq.php", homeBody)
+        myFixture.configureFromExistingVirtualFile(home.virtualFile)
+        myFixture.editor.caretModel.moveToOffset(home.text.indexOf(marker) + marker.length)
+        myFixture.completeBasic()
+        return myFixture.lookupElementStrings ?: emptyList()
+    }
+
+    fun testTemplatePathsOffered() {
+        // render('') offers the templates discovered under the roots; depending on
+        // which directory scores as the root they come through relative or as the
+        // `/`-prefixed base-absolute form, so match slash-agnostically.
+        val items = completionInside("{{ render('') }}{{ if (\$z): }}<b>z</b>{{ endif }}", "render('")
+        assertTrue("offered: $items", items.any { it.endsWith("layout/base") })
+        assertTrue("offered: $items", items.any { it.endsWith("partial/menu") })
+    }
+
+    fun testRootAbsoluteTemplatePathsOffered() {
+        val items = completionInside("{{ render('/') }}{{ if (\$z): }}<b>z</b>{{ endif }}", "render('/")
+        assertTrue(
+            "expected a root-absolute layout/base candidate, got: $items",
+            items.any { it.contains("layout/base") },
+        )
+    }
+}

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqTemplatePathCompletionFixtureTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqTemplatePathCompletionFixtureTest.kt
@@ -41,8 +41,8 @@ class QiqTemplatePathCompletionFixtureTest : BasePlatformTestCase() {
     fun testRootAbsoluteTemplatePathsOffered() {
         val items = completionInside("{{ render('/') }}{{ if (\$z): }}<b>z</b>{{ endif }}", "render('/")
         assertTrue(
-            "expected a root-absolute layout/base candidate, got: $items",
-            items.any { it.contains("layout/base") },
+            "expected a root-absolute (/-prefixed) layout/base candidate, got: $items",
+            items.any { it.startsWith("/") && it.contains("layout/base") },
         )
     }
 }

--- a/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqTemplatePathInspectionFixtureTest.kt
+++ b/src/test/kotlin/io/github/jingu/idea_qiq_plugin/fixture/QiqTemplatePathInspectionFixtureTest.kt
@@ -1,0 +1,45 @@
+package io.github.jingu.idea_qiq_plugin.fixture
+
+import com.intellij.codeInsight.daemon.impl.HighlightInfo
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import io.github.jingu.idea_qiq_plugin.inspection.QiqTemplatePathInspection
+
+/**
+ * Integration coverage for [QiqTemplatePathInspection] over a representative
+ * on-disk `qiq/{template,helper}` layout (#32): a render() to an existing template
+ * is clean, one to a missing template is flagged.
+ */
+class QiqTemplatePathInspectionFixtureTest : BasePlatformTestCase() {
+
+    private fun missingWarnings(homeBody: String): List<HighlightInfo> {
+        // The light project (and its QiqSettingsService root cache, keyed by path)
+        // is reused across test methods, so give each test a unique tree to avoid
+        // resolving a path cached against a now-deleted temp file.
+        val root = "qiq_${getTestName(true)}"
+        myFixture.addFileToProject(
+            "$root/template/layout/base.qiq.php",
+            "<html>{{= \$this->getSection('content') }}{{ if (\$x): }}<i>x</i>{{ endif }}</html>",
+        )
+        myFixture.addFileToProject(
+            "$root/template/partial/menu.qiq.php",
+            "<ul>{{ foreach (\$items as \$i): }}<li>{{= \$i }}</li>{{ endforeach }}</ul>",
+        )
+        myFixture.addFileToProject("$root/helper/Foo.php", "<?php\nclass Foo {}\n")
+        val home = myFixture.addFileToProject("$root/template/page/home.qiq.php", homeBody)
+        myFixture.configureFromExistingVirtualFile(home.virtualFile)
+        myFixture.enableInspections(QiqTemplatePathInspection())
+        return myFixture.doHighlighting(HighlightSeverity.WARNING)
+            .filter { it.description?.contains("template not found") == true }
+    }
+
+    fun testExistingTemplateNotFlagged() {
+        assertEmpty(missingWarnings("{{ render('partial/menu') }}"))
+    }
+
+    fun testMissingTemplateFlagged() {
+        val warnings = missingWarnings("{{ render('partial/nope') }}")
+        assertSize(1, warnings)
+        assertTrue(warnings[0].description, warnings[0].description.contains("partial/nope"))
+    }
+}


### PR DESCRIPTION
Closes #32.

Stands up the fixture/integration test layer the suite was missing (it was ~all pure-unit) and adds HeavyPlatformTestCase coverage for the features that were previously only manually verified. Each feature has a happy-path + at least one edge.

## Harness
- JUnit4 on the compile classpath + vintage engine so `BasePlatformTestCase` runs under `useJUnitPlatform()` next to the JUnit5 unit tests.
- `forkEvery(1)` so the platform's leaked-project hunter doesn't trip when fixture classes share an Application with the unit classes.
- `QiqFixtureSmokeTest` proves the harness boots Qiq + bundled PHP and injects PHP into a `{{ }}` host.

## Feature coverage (new fixture suites)
- **Inspections**: block pairing (#30), missing-template, section-name (#31), helper arguments (count + type).
- **Completion**: directive keywords (#34), section names (#31), template paths (relative + root-absolute), helper names.
- **Helpers**: registry discovery from a nominated bootstrap, parameter info, quick documentation — all over real PHP injection + PhpIndex resolution.
- **PSI features**: folding (#27), structure view (#29), block-pair highlighting (#28).
- **Resolution**: content-driven template-root discovery + `resolveTemplateBase` over a representative on-disk `qiq/{template,helper}` layout.

## Bug found + fixed
The new helper-arguments fixture test surfaced a real defect the pure unit test missed: a too-few-arguments warning on a no-arg call (`{{ greet() }}`) registered a problem on the zero-width empty parameter list, which the platform rejects ("Empty PSI elements must not be passed to createDescriptor"). Now anchored on the whole call when the arg list is empty.

## Verification
- `./gradlew clean build` green (192 tests, 0 failures; was 163).

🤖 Generated with [Claude Code](https://claude.com/claude-code)